### PR TITLE
DNET-550 NotSupportedException occurs when using ServerType embedded

### DIFF
--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Common/DbValue.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Common/DbValue.cs
@@ -310,7 +310,10 @@ namespace FirebirdSql.Data.Common
 
 				case DbDataType.Guid:
 					return this.GetGuid().ToByteArray();
-
+					
+				case DbDataType.Null:
+					return new byte[0];
+					
 				default:
 					throw new NotSupportedException("Unknown data type");
 			}


### PR DESCRIPTION
Found by unit-tests in our current project using fbembed.dll
