### PR TITLE
Fixed TimeStamp processing (it's not wrapped TimeSpan).

### DIFF
--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/ExternalEngine/ExtArray.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/ExternalEngine/ExtArray.cs
@@ -449,8 +449,9 @@ namespace FirebirdSql.Data.Client.ExternalEngine
 						break;
 
 					case DbDataType.TimeStamp:
-						writer.Write(TypeEncoder.EncodeDate(Convert.ToDateTime(source, CultureInfo.CurrentCulture.DateTimeFormat)));
-						writer.Write(TypeEncoder.EncodeTime((TimeSpan)source));
+						var dt = Convert.ToDateTime(source, CultureInfo.CurrentCulture.DateTimeFormat);
+						writer.Write(TypeEncoder.EncodeDate(dt));
+						writer.Write(TypeEncoder.EncodeTime(TypeHelper.DateTimeToTimeSpan(dt)));
 						break;
 
 					default:

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesArray.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesArray.cs
@@ -459,8 +459,9 @@ namespace FirebirdSql.Data.Client.Native
 						break;
 
 					case DbDataType.TimeStamp:
-						writer.Write(TypeEncoder.EncodeDate(Convert.ToDateTime(source, CultureInfo.CurrentCulture.DateTimeFormat)));
-						writer.Write(TypeEncoder.EncodeTime((TimeSpan)source));
+						var dt = Convert.ToDateTime(source, CultureInfo.CurrentCulture.DateTimeFormat);
+						writer.Write(TypeEncoder.EncodeDate(dt));
+						writer.Write(TypeEncoder.EncodeTime(TypeHelper.DateTimeToTimeSpan(dt)));
 						break;
 
 					default:


### PR DESCRIPTION
Based on feedback from @zabulus (https://github.com/cincuranet/NETProvider/pull/6).
