### PR TITLE
DNET-347 :  FbBatchExecution: Cannot determine SQL statement for ALTE…

### DIFF
--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/FbBatchExecution.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/FbBatchExecution.cs
@@ -168,6 +168,7 @@ namespace FirebirdSql.Data.Isql
 				{
 					switch (statementType)
 					{
+						case SqlStatementType.AlterCharacterSet:
 						case SqlStatementType.AlterDatabase:
 						case SqlStatementType.AlterDomain:
 						case SqlStatementType.AlterException:
@@ -747,7 +748,11 @@ namespace FirebirdSql.Data.Isql
 			switch (type)
 			{
 				case 'A':
-					if (StringParser.StartsWith(sqlStatement, "ALTER DATABASE", true))
+					if (StringParser.StartsWith(sqlStatement, "ALTER CHARACTER SET", true))
+					{
+						return SqlStatementType.AlterCharacterSet;
+					}
+					if ((StringParser.StartsWith(sqlStatement, "ALTER DATABASE", true)))
 					{
 						return SqlStatementType.AlterDatabase;
 					}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/SqlStatementType.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/SqlStatementType.cs
@@ -31,14 +31,14 @@ namespace FirebirdSql.Data.Isql
 	public enum SqlStatementType
 	{
 		/// <summary>
-		/// Represents the SQL statement: <b>ALTER DATABASE</b>
-		/// </summary>
-		AlterDatabase = 0,
-
-		/// <summary>
 		/// Represents the SQL statement: <b>ALTER CHARACTER SET</b>
 		/// </summary>
-		AlterCharacterSet,
+		AlterCharacterSet = 0,
+
+		/// <summary>
+		/// Represents the SQL statement: <b>ALTER DATABASE</b>
+		/// </summary>
+		AlterDatabase,
 
 		/// <summary>
 		/// Represents the SQL statement: <b>ALTER DOMAIN</b>

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/SqlStatementType.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/SqlStatementType.cs
@@ -36,6 +36,11 @@ namespace FirebirdSql.Data.Isql
 		AlterDatabase = 0,
 
 		/// <summary>
+		/// Represents the SQL statement: <b>ALTER CHARACTER SET</b>
+		/// </summary>
+		AlterCharacterSet,
+
+		/// <summary>
 		/// Represents the SQL statement: <b>ALTER DOMAIN</b>
 		/// </summary>
 		AlterDomain,


### PR DESCRIPTION
No unit tests provided, but if you execute the following code, we can check in table `RDB$CHARACTER_SETS` that default collations has changed :

```C#
FbScript fbScript = new FbScript("ALTER CHARACTER SET utf8 SET DEFAULT COLLATION unicode_ci_ai;\r\nALTER CHARACTER SET ISO8859_1 SET DEFAULT COLLATION FR_FR;");
fbScript.Parse();

FbBatchExecution fbBatch = new FbBatchExecution(new FbConnection(connString));
fbBatch.AppendSqlStatements(fbScript);
fbBatch.Execute(autoCommit: true);
```