### PR TITLE
DNET-532

### DIFF
--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbParameter.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbParameter.cs
@@ -63,6 +63,10 @@ namespace FirebirdSql.Data.FirebirdClient
 				_parameterName = value;
 				_internalParameterName = NormalizeParameterName(value);
 				_isUnicodeParameterName = Encoding.UTF8.GetByteCount(value) != value.Length;
+				if (_parent != null)
+				{
+					_parent.ParameterNameFlagEvaluated = false;
+				}
 			}
 		}
 
@@ -215,7 +219,19 @@ namespace FirebirdSql.Data.FirebirdClient
 		internal FbParameterCollection Parent
 		{
 			get { return _parent; }
-			set { _parent = value; }
+			set
+			{
+				if (_parent != null)
+				{
+					_parent.ParameterNameFlagEvaluated = false;
+				}
+
+				_parent = value;
+				if (value != null)
+				{
+					value.ParameterNameFlagEvaluated = false;
+				}
+			}
 		}
 
 		internal string InternalParameterName

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbParameter.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbParameter.cs
@@ -25,6 +25,7 @@ using System.Data.Common;
 using System.ComponentModel;
 
 using FirebirdSql.Data.Common;
+using System.Text;
 
 namespace FirebirdSql.Data.FirebirdClient
 {
@@ -47,6 +48,7 @@ namespace FirebirdSql.Data.FirebirdClient
 		private string _parameterName;
 		private string _sourceColumn;
 		private string _internalParameterName;
+		private bool _isUnicodeParameterName;
 
 		#endregion
 
@@ -60,7 +62,8 @@ namespace FirebirdSql.Data.FirebirdClient
 			{
 				_parameterName = value;
 				_internalParameterName = NormalizeParameterName(value);
-		}
+				_isUnicodeParameterName = Encoding.UTF8.GetByteCount(value) != value.Length;
+			}
 		}
 
 		[Category("Data")]
@@ -456,6 +459,14 @@ namespace FirebirdSql.Data.FirebirdClient
 					return bvalue.Length;
 				}
 				return null;
+			}
+		}
+
+		internal bool IsUnicodeParameterName
+		{
+			get
+			{
+				return _isUnicodeParameterName;
 			}
 		}
 

--- a/NETProvider/src/FirebirdSql.Data.UnitTests/FbParameterCollectionTests.cs
+++ b/NETProvider/src/FirebirdSql.Data.UnitTests/FbParameterCollectionTests.cs
@@ -103,6 +103,25 @@ namespace FirebirdSql.Data.UnitTests
 			Assert.IsTrue(collection.CollectionHasParameterWithUnicodeName);
 		}
 
+		[Test]
+		public void CheckFbParameterParentPropertyInvariant()
+		{
+			var collection = new FbParameterCollection();
+			var parameter = collection.Add("Name", FbDbType.Array);
+			Assert.AreSame(collection, parameter.Parent);
+			Assert.Throws<ArgumentException>(() => collection.Add(parameter));
+			Assert.Throws<ArgumentException>(() => collection.AddRange(new FbParameter[] { parameter }));
+
+			collection.Remove(parameter);
+			Assert.IsNull(parameter.Parent);
+
+			Assert.Throws<ArgumentException>(() => collection.Remove(parameter));
+
+			collection.Insert(0, parameter);
+			Assert.AreSame(collection, parameter.Parent);
+			Assert.Throws<ArgumentException>(() => collection.Insert(0, parameter));
+		}
+
 		#endregion
 	}
 }

--- a/NETProvider/src/FirebirdSql.Data.UnitTests/FbParameterCollectionTests.cs
+++ b/NETProvider/src/FirebirdSql.Data.UnitTests/FbParameterCollectionTests.cs
@@ -23,19 +23,9 @@ using NUnit.Framework;
 
 namespace FirebirdSql.Data.UnitTests
 {
-	[TestFixture(FbServerType.Default)]
-	[TestFixture(FbServerType.Embedded)]
-	public class FbParameterCollectionTests : TestsBase
+	[TestFixture]
+	public class FbParameterCollectionTests
 	{
-		#region Constructors
-
-		public FbParameterCollectionTests(FbServerType serverType)
-			: base(serverType)
-		{
-		}
-
-		#endregion
-
 		#region Unit Tests
 
 		[Test]
@@ -47,6 +37,70 @@ namespace FirebirdSql.Data.UnitTests
 			command.Parameters.Add("@p01", FbDbType.Integer);
 			command.Parameters.Add("@p02", 289273);
 			command.Parameters.Add("#p3", FbDbType.SmallInt, 2, "sourceColumn");
+		}
+
+		[Test]
+		public void DNET_532_CheckCultureAwareIndexOf()
+		{
+			var curCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+            try
+			{
+				System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("tr-TR");
+				FbCommand command = new FbCommand();
+
+				// \u0131 is turkish symbol "i without dot" that uppercases to "I" symbol.
+				// see https://msdn.microsoft.com/en-us/library/ms973919.aspx#stringsinnet20_topic5 for more information
+				var parameterName = "Turkish\u0131Parameter";
+				command.Parameters.Add(parameterName, FbDbType.Char);
+				Assert.AreNotEqual(-1, command.Parameters.IndexOf("turkishIParameter"));
+			}
+			finally
+			{
+				System.Threading.Thread.CurrentThread.CurrentCulture = curCulture;
+            }
+		}
+
+		[Test]
+		public void DNET_532_CheckFlagForUsingOrdinalIgnoreCase()
+		{			
+			FbCommand command = new FbCommand();
+			command.Parameters.IndexOf("SomeField");
+
+			for (int i = 0; i < 100; ++i)
+			{
+				command.Parameters.Add("FIELD" + i.ToString(), FbDbType.Integer);
+			}
+
+			const string probeParameterName = "FIELD0";
+			const int noMatterValue = 12345;
+			const int deleteIndex = 12;
+			command.Parameters[probeParameterName].Value = noMatterValue;
+			Assert.IsFalse(command.Parameters.CollectionHasParameterWithUnicodeName);
+
+			command.Parameters.Remove(command.Parameters[deleteIndex]);
+			command.Parameters[probeParameterName].Value = noMatterValue;
+
+			command.Parameters.RemoveAt(deleteIndex);
+			command.Parameters[probeParameterName].Value = noMatterValue;
+
+			command.Parameters.Insert(deleteIndex, new FbParameter("FIELD101", FbDbType.Integer));
+			command.Parameters[probeParameterName].Value = noMatterValue;
+
+			command.Parameters.Clear();
+		}
+
+		[Test]
+		public void DNET_532_CheckFlagForUsingOrdinalIgnoreCaseWithOuterChanges()
+		{
+			var collection = new FbParameterCollection();
+			var parameter = new FbParameter() { ParameterName = "test" };
+			collection.Add(parameter);
+			var dummy1 = collection.IndexOf("dummy");
+			Assert.IsFalse(collection.CollectionHasParameterWithUnicodeName);
+			parameter.ParameterName = "řčšřčšřčš";
+			var dummy2 = collection.IndexOf("dummy");
+			Assert.IsTrue(parameter.IsUnicodeParameterName);
+			Assert.IsTrue(collection.CollectionHasParameterWithUnicodeName);
 		}
 
 		#endregion


### PR DESCRIPTION
1. I've added test for culture aware comparison of parameter names.
2. I've added fallback to ordinal comparison in case parameter names don't have unicode characters.
3. Also added a little improvement to Remove method. It removes double comparison via Contains before deleting element from list.

About second I have doubts, the implementation is not very clean. Though, for original case difference between "by index" vs "by name" is about 4 seconds.