### PR TITLE
[WIP] Expose Async methods for FbCommand

### DIFF
--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Common/TaskHelpers.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Common/TaskHelpers.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.Common
+{
+	internal static class TaskHelpers
+	{
+		public static Task<TResult> FromException<TResult>(Exception exc)
+		{
+			var tcs = new TaskCompletionSource<TResult>();
+			tcs.SetException(exc);
+			return tcs.Task;
+		}
+	}
+}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
@@ -599,7 +599,7 @@ namespace FirebirdSql.Data.FirebirdClient
 			return ((Func<CommandBehavior, FbDataReader>)this.ExecuteReader).BeginInvoke(behavior, callback, objectState);
 		}
 
-#if NET4_5
+#if NET_45
 		public IAsyncResult BeginExecuteReader2( AsyncCallback callback, object objectState)
 		{
 			ExecuteDbReaderState state = (ExecuteDbReaderState)objectState;
@@ -620,7 +620,7 @@ namespace FirebirdSql.Data.FirebirdClient
 			}
 		}
 
-#if NET4_5
+#if NET_45
 		public DbDataReader EndExecuteReader2(IAsyncResult asyncResult)
 		{
 			ExecuteDbReaderState state = (ExecuteDbReaderState)asyncResult.AsyncState;

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
@@ -262,6 +262,10 @@ namespace FirebirdSql.Data.FirebirdClient
 #if NET_45
 		public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
 		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				throw new OperationCanceledException(cancellationToken);
+			}
 
 			CheckState();
 

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
@@ -26,7 +26,8 @@ using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using FirebirdSql.Data.Common;
 
 namespace FirebirdSql.Data.FirebirdClient
@@ -258,7 +259,42 @@ namespace FirebirdSql.Data.FirebirdClient
 
 			return retValue;
 		}
+#if NET_45
+		public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
+		{
 
+			CheckState();
+
+			bool retValue = false;
+
+			if (IsCommandBehavior(CommandBehavior.SingleRow) &&
+				_position != STARTPOS)
+			{
+			}
+			else
+			{
+				if (IsCommandBehavior(CommandBehavior.SchemaOnly))
+				{
+				}
+				else
+				{
+					_row = await Task.Factory.StartNew(() => _command.Fetch());
+
+					if (_row != null)
+					{
+						_position++;
+						retValue = true;
+					}
+					else
+					{
+						_eof = true;
+					}
+				}
+			}
+
+			return retValue;
+		}
+#endif
 		public override DataTable GetSchemaTable()
 		{
 			CheckState();
@@ -680,9 +716,9 @@ namespace FirebirdSql.Data.FirebirdClient
 			return false;
 		}
 
-		#endregion
+#endregion
 
-		#region Private Methods
+#region Private Methods
 
 		private void CheckPosition()
 		{
@@ -761,9 +797,9 @@ namespace FirebirdSql.Data.FirebirdClient
 			return index;
 		}
 
-		#endregion
+#endregion
 
-		#region Static Methods
+#region Static Methods
 
 		private static bool IsReadOnly(FbDataReader r)
 		{
@@ -852,6 +888,6 @@ namespace FirebirdSql.Data.FirebirdClient
 			}
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Common\IscErrorMessages.cs" />
     <Compile Include="Common\PageSizeHelper.cs" />
     <Compile Include="Common\SqlStateMapping.cs" />
+    <Compile Include="Common\TaskHelpers.cs" />
     <Compile Include="Common\TimeoutHelper.cs" />
     <Compile Include="Common\TraceHelper.cs" />
     <Compile Include="Entity\DmlSqlGenerator.cs" />

--- a/NETProvider/src/FirebirdSql.Data.UnitTests/FbCommandAsyncTests.cs
+++ b/NETProvider/src/FirebirdSql.Data.UnitTests/FbCommandAsyncTests.cs
@@ -1,0 +1,81 @@
+﻿#if NET_45
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FirebirdSql.Data.FirebirdClient;
+
+namespace FirebirdSql.Data.UnitTests
+{
+	[TestFixture(FbServerType.Default)]
+	[TestFixture(FbServerType.Embedded)]
+	public class FbCommandAsyncTests : TestsBase
+	{
+		public FbCommandAsyncTests(FbServerType serverType)
+			: base(serverType)
+		{ }
+
+		[Test]
+		public void TestExecuteScalarAsync()
+		{
+			string query = "SELECT FIRST(1) int_field from test";
+			using (var command = this.Connection.CreateCommand())
+			{
+				command.CommandText = query;
+				Task<object> ret = command.ExecuteScalarAsync();
+				// If runs in another thread ret.Wait will return false. If call is not async it will be already executed and Wait returns true
+				Assert.False(ret.Wait(0));
+				ret.Wait();
+			}
+		}
+
+		[Test]
+		public void TestExecuteNonQueryAsync()
+		{
+			string query = "SELECT FIRST(1) int_field from test";
+			using (var command = this.Connection.CreateCommand())
+			{
+				command.CommandText = query;
+				Task<int> ret = command.ExecuteNonQueryAsync();
+				// If runs in another thread ret.Wait will return false. If call is not async it will be already executed and Wait returns true
+				Assert.False(ret.Wait(0));
+				ret.Wait();
+			}
+		}
+
+		[Test]
+		public void TestExecuteReaderAsync()
+		{
+			using (FbTransaction transaction = Connection.BeginTransaction())
+			{
+				using (FbCommand command = new FbCommand("select * from TEST", Connection, transaction))
+				{
+					Console.WriteLine();
+					Console.WriteLine("DataReader - Read Method - Test");
+
+					var readerOpenTask = command.ExecuteReaderAsync();
+					Assert.False(readerOpenTask.Wait(0));
+					using (var reader = readerOpenTask.Result )
+					{
+						var readTask = reader.ReadAsync();
+						Assert.False(readTask.Wait(0));
+						while (readTask.Result)
+						{
+							for (int i = 0; i < reader.FieldCount; i++)
+							{
+								Console.Write(reader.GetValue(i) + "\t");
+							}							
+
+							readTask = reader.ReadAsync();
+							// do not check readTask time for Default server, because GdsStatement reads several records at once, and they already read.
+							// FesStatement also can read record very fast.
+						}
+					}
+				}
+			}
+		}
+    }
+}
+#endif

--- a/NETProvider/src/FirebirdSql.Data.UnitTests/FirebirdSql.Data.UnitTests.csproj
+++ b/NETProvider/src/FirebirdSql.Data.UnitTests/FirebirdSql.Data.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NETProvider/src/FirebirdSql.Data.UnitTests/FirebirdSql.Data.UnitTests.csproj
+++ b/NETProvider/src/FirebirdSql.Data.UnitTests/FirebirdSql.Data.UnitTests.csproj
@@ -84,6 +84,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FbCommandAsyncTests.cs" />
     <Compile Include="FbConnectionStringTests.cs" />
     <Compile Include="FbExceptionTests.cs" />
     <Compile Include="TestsSetup.cs" />


### PR DESCRIPTION
During exploitation of Async EF queries in our project, I've found out that every query runs in sync when use Fb .NET provider. Indeed, https://github.com/Microsoft/referencesource/blob/master/System.Data/System/Data/Common/DBCommand.cs#L219 DbCommand returns ```Task.FromResult(non-async call)``` if async overload is not provided.

This is initial commit for adding Async methods to ```FbCommand``` class. It only uses already exposed Begin/End methods already exists in FbCommand via ```Task.Factory.FromAsync```.
I'm planning to do next things:
1. Add using CancellationToken in async methods, so they could be trully cancellable.
2. Replace ```Task.Factory.StartNew``` calls with API async calls if exists or starting brand new thread.
3. Cache delegate for BeginExecuterReader2.
