### PR TITLE
Native holders

### DIFF
--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/ExternalEngine/ExtBlob.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/ExternalEngine/ExtBlob.cs
@@ -28,6 +28,7 @@ namespace FirebirdSql.Data.Client.ExternalEngine
 		#region Fields
 
 		private ExtDatabase _db;
+		private int _blobHandle;
 
 		#endregion
 
@@ -36,6 +37,11 @@ namespace FirebirdSql.Data.Client.ExternalEngine
 		public override IDatabase Database
 		{
 			get { return _db; }
+		}
+
+		public override int Handle
+		{
+			get { return _blobHandle; }
 		}
 
 		#endregion

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version10/GdsBlob.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version10/GdsBlob.cs
@@ -28,6 +28,7 @@ namespace FirebirdSql.Data.Client.Managed.Version10
 		#region Fields
 
 		private GdsDatabase _database;
+		private int _blobHandle;
 
 		#endregion
 
@@ -36,6 +37,11 @@ namespace FirebirdSql.Data.Client.Managed.Version10
 		public override IDatabase Database
 		{
 			get { return _database; }
+		}
+
+		public override int Handle
+		{
+			get { return _blobHandle; }
 		}
 
 		#endregion

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesArray.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesArray.cs
@@ -29,6 +29,7 @@ using System.Text;
 
 using FirebirdSql.Data.Common;
 using FirebirdSql.Data.Client.Common;
+using FirebirdSql.Data.Client.Native.Handle;
 
 namespace FirebirdSql.Data.Client.Native
 {
@@ -115,8 +116,8 @@ namespace FirebirdSql.Data.Client.Native
 			// Clear the status vector
 			ClearStatusVector();
 
-			int dbHandle = _db.Handle;
-			int trHandle = _transaction.Handle;
+			DatabaseHandle dbHandle = _db.HandlePtr;
+			TransactionHandle trHandle = _transaction.HandlePtr;
 
 			IntPtr arrayDesc = ArrayDescMarshaler.MarshalManagedToNative(Descriptor);
 
@@ -144,8 +145,8 @@ namespace FirebirdSql.Data.Client.Native
 			// Clear the status vector
 			ClearStatusVector();
 
-			int dbHandle = _db.Handle;
-			int trHandle = _transaction.Handle;
+			DatabaseHandle dbHandle = _db.HandlePtr;
+			TransactionHandle trHandle = _transaction.HandlePtr;
 
 			IntPtr arrayDesc = ArrayDescMarshaler.MarshalManagedToNative(Descriptor);
 

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesBlob.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesBlob.cs
@@ -23,6 +23,7 @@ using System;
 using System.IO;
 
 using FirebirdSql.Data.Common;
+using FirebirdSql.Data.Client.Native.Handle;
 
 namespace FirebirdSql.Data.Client.Native
 {
@@ -32,6 +33,7 @@ namespace FirebirdSql.Data.Client.Native
 
 		private FesDatabase _db;
 		private IntPtr[] _statusVector;
+		private BlobHandle _blobHandle;
 
 		#endregion
 
@@ -40,6 +42,11 @@ namespace FirebirdSql.Data.Client.Native
 		public override IDatabase Database
 		{
 			get { return _db; }
+		}
+
+		public override int Handle
+		{
+			get { return _blobHandle.DangerousGetHandle().AsInt(); }
 		}
 
 		#endregion
@@ -66,7 +73,7 @@ namespace FirebirdSql.Data.Client.Native
 			_db = (FesDatabase)db;
 			_transaction = (FesTransaction)transaction;
 			_position = 0;
-			_blobHandle = 0;
+			_blobHandle = new BlobHandle();
 			_blobId = blobId;
 			_statusVector = new IntPtr[IscCodes.ISC_STATUS_LENGTH];
 		}
@@ -82,8 +89,8 @@ namespace FirebirdSql.Data.Client.Native
 				// Clear the status vector
 				ClearStatusVector();
 
-				int dbHandle = _db.Handle;
-				int trHandle = _transaction.Handle;
+				DatabaseHandle dbHandle = _db.HandlePtr;
+				TransactionHandle trHandle = ((FesTransaction)_transaction).HandlePtr;
 
 				_db.FbClient.isc_create_blob2(
 					_statusVector,
@@ -107,8 +114,8 @@ namespace FirebirdSql.Data.Client.Native
 				// Clear the status vector
 				ClearStatusVector();
 
-				int dbHandle = _db.Handle;
-				int trHandle = _transaction.Handle;
+				DatabaseHandle dbHandle = _db.HandlePtr;
+				TransactionHandle trHandle = ((FesTransaction)_transaction).HandlePtr;
 
 				_db.FbClient.isc_open_blob2(
 					_statusVector,

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/BlobHandle.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/BlobHandle.cs
@@ -1,0 +1,28 @@
+﻿using FirebirdSql.Data.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.Client.Native.Handle
+{
+	// public visibility added, because auto-generated assembly can't work with internal types
+	public class BlobHandle : FirebirdHandle
+	{
+		protected override bool ReleaseHandle()
+		{
+			if (this.IsClosed)
+			{
+				return true;
+			}
+
+			IntPtr[] statusVector = new IntPtr[IscCodes.ISC_STATUS_LENGTH];
+			BlobHandle @ref = this;
+			_fbClient.isc_close_blob(statusVector, ref @ref);
+			handle = @ref.handle;
+			var exception = FesConnection.ParseStatusVector(statusVector, Charset.DefaultCharset);
+			return exception == null || exception.IsWarning;
+		}
+	}
+}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/DatabaseHandle.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/DatabaseHandle.cs
@@ -1,0 +1,31 @@
+﻿using FirebirdSql.Data.Common;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.Client.Native.Handle
+{
+	// public visibility added, because auto-generated assembly can't work with internal types
+	public class DatabaseHandle : FirebirdHandle
+	{
+		protected override bool ReleaseHandle()
+		{
+			Contract.Requires(_fbClient != null);
+
+			if (IsClosed)
+			{
+				return true;
+			}
+
+			IntPtr[] statusVector = new IntPtr[IscCodes.ISC_STATUS_LENGTH];
+			DatabaseHandle @ref = this;
+			_fbClient.isc_detach_database(statusVector, ref @ref);
+			handle = @ref.handle;
+			var exception = FesConnection.ParseStatusVector(statusVector, Charset.DefaultCharset);
+			return exception == null || exception.IsWarning;
+		}
+	}
+}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/FirebirdHandle.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/FirebirdHandle.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.Client.Native.Handle
+{
+	// public visibility added, because auto-generated assembly can't work with internal types
+	public abstract class FirebirdHandle : SafeHandle , IFirebirdHandle
+	{
+		protected IFbClient _fbClient;
+
+		protected FirebirdHandle()
+			: base(IntPtr.Zero, true)
+		{
+
+		}
+
+		// Method added because we can't inject IFbClient in ctor
+		void IFirebirdHandle.SetClient(IFbClient fbClient)
+		{
+			Contract.Requires(_fbClient == null); // We shouldn't set this if already set
+			Contract.Requires(fbClient != null);
+			Contract.Ensures(_fbClient != null);
+
+			_fbClient = fbClient;
+		}
+
+		public override bool IsInvalid
+		{
+			get
+			{
+				return handle == IntPtr.Zero;
+			}
+		}
+	}
+}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/IFirebirdHandle.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/IFirebirdHandle.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.Client.Native.Handle
+{
+	// public visibility added, because auto-generated assembly can't work with internal types
+	public interface IFirebirdHandle
+	{
+		void SetClient(IFbClient fbClient);
+	}
+}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/StatementHandle.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/StatementHandle.cs
@@ -1,0 +1,32 @@
+﻿using FirebirdSql.Data.Common;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.Client.Native.Handle
+{
+	// public visibility added, because auto-generated assembly can't work with internal types
+	public class StatementHandle : FirebirdHandle
+	{
+		protected override bool ReleaseHandle()
+		{
+			Contract.Requires(_fbClient != null);
+
+			if (this.IsClosed)
+			{
+				return true;
+			}
+
+			IntPtr[] statusVector = new IntPtr[IscCodes.ISC_STATUS_LENGTH];
+			StatementHandle @ref = this;
+			_fbClient.isc_dsql_free_statement(statusVector, ref @ref, IscCodes.DSQL_drop);
+			handle = @ref.handle;
+
+			var exception = FesConnection.ParseStatusVector(statusVector, Charset.DefaultCharset);
+			return exception == null || exception.IsWarning;
+		}
+	}
+}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/TransactionHandle.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/Handle/TransactionHandle.cs
@@ -1,0 +1,31 @@
+﻿using FirebirdSql.Data.Common;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.Client.Native.Handle
+{
+	// public visibility added, because auto-generated assembly can't work with internal types
+	public class TransactionHandle : FirebirdHandle
+	{
+		protected override bool ReleaseHandle()
+		{
+			Contract.Requires(_fbClient != null);
+
+			if (this.IsClosed)
+			{
+				return true;
+			}
+
+			IntPtr[] statusVector = new IntPtr[IscCodes.ISC_STATUS_LENGTH];
+			TransactionHandle @ref = this;
+			_fbClient.isc_rollback_transaction(statusVector, ref @ref);
+			handle = @ref.handle;
+			var exception = FesConnection.ParseStatusVector(statusVector, Charset.DefaultCharset);
+			return exception == null || exception.IsWarning;
+		}
+	}
+}

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/IFbClient.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Client/Native/IFbClient.cs
@@ -20,13 +20,19 @@
  *      Jiri Cincura (jiri@cincura.net)
  */
 
+using FirebirdSql.Data.Client.Native.Handle;
+using FirebirdSql.Data.Common;
 using System;
+using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 
 namespace FirebirdSql.Data.Client.Native
 {
 	/// <summary>
-	/// This is the interface that the dynamically-generated class uses to call the native library.
+	/// This is the interface that the dynamically-generated class uses to call the native library. 
+	/// Each connection can specify different client library to use even on the same OS. 
+	/// IFbClient and FbClientactory classes are implemented to support this feature.
+	/// Public visibility added, because auto-generated assembly can't work with internal types
 	/// </summary>
 	public interface IFbClient
 	{
@@ -34,21 +40,21 @@ namespace FirebirdSql.Data.Client.Native
 
 		IntPtr isc_array_get_slice(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle,
-			ref	int trHandle,
-			ref	long arrayId,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
+			ref long arrayId,
 			IntPtr desc,
 			byte[] destArray,
-			ref	int sliceLength);
+			ref int sliceLength);
 
 		IntPtr isc_array_put_slice(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle,
-			ref	int trHandle,
-			ref	long arrayId,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
+			ref long arrayId,
 			IntPtr desc,
 			byte[] sourceArray,
-			ref	int sliceLength);
+			ref int sliceLength);
 
 		#endregion
 
@@ -56,42 +62,42 @@ namespace FirebirdSql.Data.Client.Native
 
 		IntPtr isc_create_blob2(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle,
-			ref	int trHandle,
-			ref	int blobHandle,
-			ref	long blobId,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
+			[MarshalAs(UnmanagedType.I4)] ref BlobHandle blobHandle,
+			ref long blobId,
 			short bpbLength,
 			byte[] bpbAddress);
 
 		IntPtr isc_open_blob2(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle,
-			ref	int trHandle,
-			ref	int blobHandle,
-			ref	long blobId,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
+			[MarshalAs(UnmanagedType.I4)] ref BlobHandle blobHandle,
+			ref long blobId,
 			short bpbLength,
 			byte[] bpbAddress);
 
 		IntPtr isc_get_segment(
 			[In, Out] IntPtr[] statusVector,
-			ref	int blobHandle,
-			ref	short actualSegLength,
+			[MarshalAs(UnmanagedType.I4)] ref BlobHandle blobHandle,
+			ref short actualSegLength,
 			short segBufferLength,
 			byte[] segBuffer);
 
 		IntPtr isc_put_segment(
 			[In, Out] IntPtr[] statusVector,
-			ref	int blobHandle,
+			[MarshalAs(UnmanagedType.I4)] ref BlobHandle blobHandle,
 			short segBufferLength,
 			byte[] segBuffer);
 
 		IntPtr isc_cancel_blob(
 			[In, Out] IntPtr[] statusVector,
-			ref	int blobHandle);
+			[MarshalAs(UnmanagedType.I4)] ref BlobHandle blobHandle);
 
 		IntPtr isc_close_blob(
 			[In, Out] IntPtr[] statusVector,
-			ref	int blobHandle);
+			[MarshalAs(UnmanagedType.I4)] ref BlobHandle blobHandle);
 
 		#endregion
 
@@ -101,17 +107,17 @@ namespace FirebirdSql.Data.Client.Native
 			[In, Out] IntPtr[] statusVector,
 			short dbNameLength,
 			byte[] dbName,
-			ref	int dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
 			short parmBufferLength,
 			byte[] parmBuffer);
 
 		IntPtr isc_detach_database(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle);
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle);
 
 		IntPtr isc_database_info(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
 			short itemListBufferLength,
 			byte[] itemListBuffer,
 			short resultBufferLength,
@@ -121,40 +127,39 @@ namespace FirebirdSql.Data.Client.Native
 			[In, Out] IntPtr[] statusVector,
 			short dbNameLength,
 			byte[] dbName,
-			ref	int dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
 			short parmBufferLength,
 			byte[] parmBuffer,
 			short dbType);
-
 		IntPtr isc_drop_database(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle);
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle);
 
 		#endregion
 
 		#region Transaction Functions
 
 		IntPtr isc_start_multiple(
-			[In, Out]	IntPtr[] statusVector,
-			ref	int trHandle,
+			[In, Out]   IntPtr[] statusVector,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
 			short dbHandleCount,
 			IntPtr tebVectorAddress);
 
 		IntPtr isc_commit_transaction(
 			[In, Out] IntPtr[] statusVector,
-			ref	int trHandle);
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle);
 
 		IntPtr isc_commit_retaining(
 			[In, Out] IntPtr[] statusVector,
-			ref	int trHandle);
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle);
 
 		IntPtr isc_rollback_transaction(
 			[In, Out] IntPtr[] statusVector,
-			ref	int trHandle);
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle);
 
 		IntPtr isc_rollback_retaining(
 			[In, Out] IntPtr[] statusVector,
-			ref	int trHandle);
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle);
 
 		#endregion
 
@@ -162,7 +167,7 @@ namespace FirebirdSql.Data.Client.Native
 
 		IntPtr fb_cancel_operation(
 			[In, Out] IntPtr[] statusVector,
-			ref int dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
 			int option);
 
 		#endregion
@@ -171,25 +176,25 @@ namespace FirebirdSql.Data.Client.Native
 
 		IntPtr isc_dsql_allocate_statement(
 			[In, Out] IntPtr[] statusVector,
-			ref	int dbHandle,
-			ref	int stmtHandle);
+			[MarshalAs(UnmanagedType.I4)] ref DatabaseHandle dbHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle);
 
 		IntPtr isc_dsql_describe(
 			[In, Out] IntPtr[] statusVector,
-			ref	int stmtHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short daVersion,
 			IntPtr xsqlda);
 
 		IntPtr isc_dsql_describe_bind(
 			[In, Out] IntPtr[] statusVector,
-			ref	int stmtHandle,
+			 [MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short daVersion,
 			IntPtr xsqlda);
 
 		IntPtr isc_dsql_prepare(
 			[In, Out] IntPtr[] statusVector,
-			ref	int trHandle,
-			ref	int stmtHandle,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short length,
 			byte[] statement,
 			short dialect,
@@ -197,33 +202,33 @@ namespace FirebirdSql.Data.Client.Native
 
 		IntPtr isc_dsql_execute(
 			[In, Out] IntPtr[] statusVector,
-			ref	int trHandle,
-			ref	int stmtHandle,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short daVersion,
 			IntPtr xsqlda);
 
 		IntPtr isc_dsql_execute2(
 			[In, Out] IntPtr[] statusVector,
-			ref	int trHandle,
-			ref	int stmtHandle,
+			[MarshalAs(UnmanagedType.I4)] ref TransactionHandle trHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short da_version,
 			IntPtr inXsqlda,
 			IntPtr outXsqlda);
 
 		IntPtr isc_dsql_fetch(
 			[In, Out] IntPtr[] statusVector,
-			ref	int stmtHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short daVersion,
 			IntPtr xsqlda);
 
 		IntPtr isc_dsql_free_statement(
 			[In, Out] IntPtr[] statusVector,
-			ref	int stmtHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short option);
 
 		IntPtr isc_dsql_sql_info(
 			[In, Out] IntPtr[] statusVector,
-			ref	int stmtHandle,
+			[MarshalAs(UnmanagedType.I4)] ref StatementHandle stmtHandle,
 			short itemsLength,
 			byte[] items,
 			short bufferLength,
@@ -241,25 +246,25 @@ namespace FirebirdSql.Data.Client.Native
 			[In, Out] IntPtr[] statusVector,
 			short serviceLength,
 			string service,
-			ref	int svcHandle,
+			ref int svcHandle,
 			short spbLength,
 			byte[] spb);
 
 		IntPtr isc_service_start(
 			[In, Out] IntPtr[] statusVector,
-			ref	int svcHandle,
-			ref	int reserved,
+			ref int svcHandle,
+			ref int reserved,
 			short spbLength,
 			byte[] spb);
 
 		IntPtr isc_service_detach(
 			[In, Out] IntPtr[] statusVector,
-			ref	int svcHandle);
+			ref int svcHandle);
 
 		IntPtr isc_service_query(
 			[In, Out] IntPtr[] statusVector,
-			ref	int svcHandle,
-			ref	int reserved,
+			ref int svcHandle,
+			ref int reserved,
 			short sendSpbLength,
 			byte[] sendSpb,
 			short requestSpbLength,

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Common/BlobBase.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Common/BlobBase.cs
@@ -36,9 +36,9 @@ namespace FirebirdSql.Data.Common
 
 		#region Properties
 
-		public int Handle
+		public abstract int Handle
 		{
-			get { return _blobHandle; }
+			get;
 		}
 
 		public long Id
@@ -56,7 +56,6 @@ namespace FirebirdSql.Data.Common
 		#region Protected Fields
 
 		protected long          _blobId;
-		protected int           _blobHandle;
 		protected int           _position;
 		protected ITransaction  _transaction;
 

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
@@ -364,7 +364,7 @@ namespace FirebirdSql.Data.FirebirdClient
 		{
 			lock (this)
 			{
-				if (!_disposed)
+				if (!_disposed && disposing)
 				{
 					try
 					{

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -139,6 +139,12 @@
     <Compile Include="Client\Managed\Version11\SSPIHelper.cs" />
     <Compile Include="Client\Managed\Version12\GdsDatabase.cs" />
     <Compile Include="Client\Managed\Version12\GdsStatement.cs" />
+    <Compile Include="Client\Native\Handle\BlobHandle.cs" />
+    <Compile Include="Client\Native\Handle\DatabaseHandle.cs" />
+    <Compile Include="Client\Native\Handle\FirebirdHandle.cs" />
+    <Compile Include="Client\Native\Handle\IFirebirdHandle.cs" />
+    <Compile Include="Client\Native\Handle\StatementHandle.cs" />
+    <Compile Include="Client\Native\Handle\TransactionHandle.cs" />
     <Compile Include="Common\Extensions.cs" />
     <Compile Include="Common\IscErrorMessages.cs" />
     <Compile Include="Common\PageSizeHelper.cs" />

--- a/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/SqlStringParser.cs
+++ b/NETProvider/src/FirebirdSql.Data.FirebirdClient/Isql/SqlStringParser.cs
@@ -112,12 +112,16 @@ namespace FirebirdSql.Data.Isql
 
 			if (index >= _sourceLength)
 			{
-				var parsed = _source.Substring(lastYield);
-				if (parsed.Trim() == string.Empty)
+				if (lastYield != 0)
 				{
-					yield break;
+					var parsed = _source.Substring(lastYield);
+					if (parsed.Trim() == string.Empty)
+					{
+						yield break;
+					}
+					yield return new FbStatement(parsed, rawResult.ToString());
 				}
-                yield return new FbStatement(parsed, rawResult.ToString());
+
 				lastYield = _sourceLength;
 				rawResult.Clear();
 			}


### PR DESCRIPTION
The PR introduces SafeHandle descendants that replace using raw int handles.

Purpose:
After recent changes in finalizer methods code, we've discovered increased exception occurring in finalizer thread. Most of them were from FesTransaction class, another were from FesStatement (similar to http://tracker.firebirdsql.org/browse/DNET-582, but handled with an empty catch). 
Content:
In the PR all handles are wrapped in SafeHandle descendants to use more reliable mechanism for handling native resources. 
Pros:
These changes allow to clean up Dispose\Finalize code and restrict it to clear only managed objects clearing. Changes exploit reliable primitive for handling native resources introduced as handles.
Cons:
There are several challenges left, regarding injecting IFbClient instance. 

@cincuranet could you take a look at PR, will you accept this piece of native rework?