### PR TITLE
GdsConnection: null-reference crash on Linux.

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
@@ -322,7 +322,7 @@ namespace FirebirdSql.Data.Client.Managed
 					WriteMultiPartHelper(result, IscCodes.CNCT_specific_data, specificData);
 				}
 
-				var user = Encoding.UTF8.GetBytes(Environment.GetEnvironmentVariable("USERNAME"));
+				var user = Encoding.UTF8.GetBytes(Environment.UserName);
 				result.WriteByte(IscCodes.CNCT_user);
 				result.WriteByte((byte)user.Length);
 				result.Write(user, 0, user.Length);


### PR DESCRIPTION
The reading USERNAME environment variable (which is not defined on Linux) is replaced with Environment.UserName.

Any call to FBConnection.Open() on Linux led to an ArgumentNullException thrown from  GdsConnection.UserIdentificationData() which was attempting to read USERNAME environment variable (which doesn't exist on UNIX systems). 