### PR TITLE
Added additional Constructor for FbBatchExecution

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Isql/FbBatchExecution.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Isql/FbBatchExecution.cs
@@ -79,11 +79,24 @@ namespace FirebirdSql.Data.Isql
 			}
 		}
 
-		/// <summary>
-		/// Appends SQL statements from <see cref="FbScript"/> instance. <see cref="FbScript.Parse"/> should be already called.
-		/// </summary>
-		/// <param name="isqlScript">A <see cref="FbScript"/> object.</param>
-		public void AppendSqlStatements(FbScript isqlScript)
+        /// <summary>
+        /// Creates an instance of FbBatchExecution engine with the given
+        /// connection.
+        /// </summary>
+        /// <param name="sqlConnection">A <see cref="FbConnection"/> object.</param>
+        /// <param name="isqlScript">A <see cref="FbScript"/> object.</param>
+        public FbBatchExecution(FbConnection sqlConnection = null, FbScript isqlScript = null) : this(sqlConnection)
+        {
+            if (isqlScript != null)
+                this.AppendSqlStatements(isqlScript);
+        }
+
+
+        /// <summary>
+        /// Appends SQL statements from <see cref="FbScript"/> instance. <see cref="FbScript.Parse"/> should be already called.
+        /// </summary>
+        /// <param name="isqlScript">A <see cref="FbScript"/> object.</param>
+        public void AppendSqlStatements(FbScript isqlScript)
 		{
 			_statements.AddRange(isqlScript.Results);
 		}


### PR DESCRIPTION
Contructor for FBBatchExecution used to have a second parameter accepting the FBScript values. This was later changed in 5.6 version (i believe). Most of the code which was written prior to the change are rising compilation errors due to the same, with little info or reference AppendSQLStatements Method. Considering this is a small change, wouldn't it be better if the transition is carried out in steps, may be marking it obsolete first and then removing it completely.

