### PR TITLE
Fixed invalid casting when generating downgrade migration to initial point

### DIFF
--- a/Provider/src/EntityFramework.Firebird/FbMigrationSqlGenerator.cs
+++ b/Provider/src/EntityFramework.Firebird/FbMigrationSqlGenerator.cs
@@ -59,13 +59,13 @@ namespace FirebirdSql.Data.EntityFramework6
 
 			if (historyOperation != null)
 			{
-				DbModificationCommandTree modify = historyOperation.CommandTrees.First();
+				var modify = historyOperation.CommandTrees.First();
 				_migrationsHistoryTableName = ((DbScanExpression)modify.Target.Expression).Target.Table;
 			}
 			//This happens only and only if downgrading database to initial point (ie. reverting also Initial migration)
 			else
 			{
-				var dropTableOperation = (DropTableOperation) lastOperation; //DropTableOperation for MigrationHistory-table
+				var dropTableOperation = (DropTableOperation)lastOperation; //DropTableOperation for MigrationHistory-table
 				_migrationsHistoryTableName = Regex.Replace(dropTableOperation.Name, @".+\.(.+)", "$1");
 			}
 

--- a/Provider/src/EntityFramework.Firebird/FbMigrationSqlGenerator.cs
+++ b/Provider/src/EntityFramework.Firebird/FbMigrationSqlGenerator.cs
@@ -55,9 +55,19 @@ namespace FirebirdSql.Data.EntityFramework6
 			var updateDatabaseOperation = lastOperation as UpdateDatabaseOperation;
 			var historyOperation = updateDatabaseOperation != null
 				? updateDatabaseOperation.Migrations.First().Operations.OfType<HistoryOperation>().First()
-				: (HistoryOperation)lastOperation;
-			var modify = historyOperation.CommandTrees.First();
-			_migrationsHistoryTableName = (modify.Target.Expression as DbScanExpression).Target.Table;
+				: lastOperation as HistoryOperation;
+
+			if (historyOperation != null)
+			{
+				DbModificationCommandTree modify = historyOperation.CommandTrees.First();
+				_migrationsHistoryTableName = ((DbScanExpression)modify.Target.Expression).Target.Table;
+			}
+			//This happens only and only if downgrading database to initial point (ie. reverting also Initial migration)
+			else
+			{
+				var dropTableOperation = (DropTableOperation) lastOperation; //DropTableOperation for MigrationHistory-table
+				_migrationsHistoryTableName = Regex.Replace(dropTableOperation.Name, @".+\.(.+)", "$1");
+			}
 
 			return GenerateStatements(migrationOperations).ToArray();
 		}


### PR DESCRIPTION
I fixed `InvalidCastException` that is raised in `FbMigrationSqlGenerator` when generating downgrade migration to database initial point (ie. `update-database -targetMigration: 0`, reverting also your first migration).

In this case, there is no `HistoryOperation` in `IEnumerable<MigrationOperation> migrationOperations` collection. Instead there is  `DropTableOperation` for migration history table as the last operation in the collection. 