### PR TITLE
Fix for Xamarin Android and .NET Standard 2.0

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionInternal.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionInternal.cs
@@ -22,7 +22,7 @@ using System.Text;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD1_6
 using Microsoft.Extensions.PlatformAbstractions;
 #endif
 using FirebirdSql.Data.Common;
@@ -491,8 +491,10 @@ namespace FirebirdSql.Data.FirebirdClient
 
 		private string GetHostingPath()
 		{
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD1_6
 			return PlatformServices.Default.Application.ApplicationBasePath;
+#elif NETSTANDARD2_0
+			return System.AppDomain.CurrentDomain.BaseDirectory;
 #else
 			Assembly assembly;
 			try

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionInternal.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionInternal.cs
@@ -494,7 +494,7 @@ namespace FirebirdSql.Data.FirebirdClient
 #if NETSTANDARD1_6
 			return PlatformServices.Default.Application.ApplicationBasePath;
 #elif NETSTANDARD2_0
-			return System.AppDomain.CurrentDomain.BaseDirectory;
+			return System.AppContext.BaseDirectory;
 #else
 			Assembly assembly;
 			try


### PR DESCRIPTION
This fix will make the .NET Standard 2.0 version work with Xamarin.Android. Xamarin.Android doesn't support Microsoft.Extensions.PlatformAbstractions which seems to be something that is not being supported any more with some new features in .NET Standard 2.0: https://github.com/aspnet/Announcements/issues/237

This will leave 1.6 using Microsoft.Extensions.PlatformAbstractions, but for the compile option NETSTANDARD2_0 it will switch to System.AppContext.BaseDirectory.