### PR TITLE
 Add explicit command logging switch 

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
@@ -32,6 +32,10 @@ using FirebirdSql.Data.Common;
 
 namespace FirebirdSql.Data.FirebirdClient
 {
+	public static class FbCommandOptions
+	{
+		public static bool EnableCommandLogging = true;
+	}
 	public sealed class FbCommand : DbCommand
 #if !NETSTANDARD1_6
 		, ICloneable
@@ -1323,7 +1327,7 @@ namespace FirebirdSql.Data.FirebirdClient
 		[Conditional(TraceHelper.ConditionalSymbol)]
 		private void LogCommand()
 		{
-			if (TraceHelper.HasListeners)
+			if (TraceHelper.HasListeners && FbCommandOptions.EnableCommandLogging)
 			{
 				StringBuilder message = new StringBuilder();
 				message.AppendLine("Command:");

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -11,7 +11,7 @@
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
-		<DefineConstants>RELEASE;NETSTANDARD1_6</DefineConstants>
+		<DefineConstants>TRACE</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<DefineConstants>DEBUG;TRACE</DefineConstants>

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -11,7 +11,7 @@
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
-		<DefineConstants>TRACE</DefineConstants>
+		<DefineConstants>RELEASE;NETSTANDARD1_6</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<DefineConstants>DEBUG;TRACE</DefineConstants>


### PR DESCRIPTION
In my current project (.net core command line app) I just can't seem to disable the tracing with the version from nuget. With the tracing enabled the ETL program I am debugging is extremely slow in VS 2017.
It is always a pain to remember how to disable it. Thus this tiny change.
So I can easily disable command logging with:
`
FirebirdSql.Data.FirebirdClient.FbCommandOptions.EnableCommandLogging = False
`
In my opinion it should default to disabled.

Thank You