### PR TITLE
DNET-851 Add support for case sensitive user names

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient.Tests/FbConnectionTests.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient.Tests/FbConnectionTests.cs
@@ -401,6 +401,48 @@ namespace FirebirdSql.Data.FirebirdClient.Tests
 			}
 		}
 
+		[Test]
+		public void CaseSensitiveLogin()
+		{
+			if (!EnsureVersion(new Version("3.0.0.0")))
+				return;
+
+			var connectionString = BuildConnectionString(FbServerType, Compression);
+			using (var conn = new FbConnection(connectionString))
+			{
+				conn.Open();
+				using (var cmd = conn.CreateCommand())
+				{
+					cmd.CommandText = "create or alter user \"CaseSensitive\" password 'password' using plugin Srp";
+					cmd.ExecuteNonQuery();
+				}
+
+				var csBuilder = new FbConnectionStringBuilder(connectionString)
+				{
+					Pooling = false,
+					UserID = "\"CaseSensitive\"",
+					Password = "password"
+				};
+				Console.WriteLine(csBuilder.ToString());
+				try
+				{
+					using (var conn2 = new FbConnection(csBuilder.ToString()))
+					//using (var conn2 = new FbConnection("user id='\"CaseSensitive\"';..."))
+					{
+						conn2.Open();
+					}
+				}
+				finally
+				{
+					using (var cmd = conn.CreateCommand())
+					{
+						cmd.CommandText = "drop user \"CaseSensitive\" using plugin Srp";
+						cmd.ExecuteNonQuery();
+					}
+				} 
+			}
+		}
+
 		#endregion
 
 		#region Methods

--- a/Provider/src/FirebirdSql.Data.FirebirdClient.Tests/GdsConnectionTests.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient.Tests/GdsConnectionTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirebirdSql.Data.FirebirdClient.Tests
+{
+	[TestFixture]
+	class GdsConnectionTests
+	{
+		[Test, TestCaseSource(typeof(NormalizeLoginTestData), "TestCases")]
+		public string NormalizeLoginTest(string login)
+		{
+			return Client.Managed.GdsConnection.NormalizeLogin(login);
+		}
+	}
+
+	class NormalizeLoginTestData
+	{
+		public static IEnumerable<TestCaseData> TestCases
+		{
+			get
+			{
+				yield return new TestCaseData("sysdba").Returns("SYSDBA");
+				yield return new TestCaseData("s").Returns("S");
+				yield return new TestCaseData("\"CaseSensitive\"").Returns("CaseSensitive");
+				yield return new TestCaseData("\"s\"").Returns("s");
+				yield return new TestCaseData("\"With\"\"EscapedQuote\"").Returns("With\"EscapedQuote");
+				yield return new TestCaseData("\"Invalid\"Escape\"").Returns("Invalid");
+				yield return new TestCaseData("\"DanglingInvalidEscape\"\"").Returns("DanglingInvalidEscape");
+				yield return new TestCaseData("\"EscapedQuoteAtEnd\"\"\"").Returns("EscapedQuoteAtEnd\"");
+				yield return new TestCaseData("\"StartNoEndQuote").Returns("\"STARTNOENDQUOTE");
+				yield return new TestCaseData("\"\"").Returns("\"\"");
+				yield return new TestCaseData("").Returns("");
+				yield return new TestCaseData(null).Returns(null);
+			}
+		}
+	}
+}

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
@@ -187,7 +187,7 @@ namespace FirebirdSql.Data.Client.Managed
 								switch (acceptPluginName)
 								{
 									case SrpClient.PluginName:
-										_authData = Encoding.ASCII.GetBytes(_srp.ClientProof(_userID, _password, data).ToHexString());
+										_authData = Encoding.ASCII.GetBytes(_srp.ClientProof(NormalizeLogin(_userID), _password, data).ToHexString());
 										break;
 									case SspiHelper.PluginName:
 										_authData = _sspi.GetClientSecurity(data);
@@ -383,6 +383,46 @@ namespace FirebirdSql.Data.Client.Managed
 				stream.Write(data, i, length);
 				part++;
 			}
+		}
+
+		public static string NormalizeLogin(string login)
+		{
+			if (String.IsNullOrEmpty(login))
+			{
+				return login;
+			}
+			if (login.Length > 2 && login[0] == '"' && login[login.Length - 1] == '"')
+			{
+				return NormalizeQuotedLogin(login);
+			}
+			return login.ToUpperInvariant();
+		}
+
+		private static string NormalizeQuotedLogin(string login)
+		{
+			var sb = new StringBuilder(login, 1, login.Length - 2, login.Length - 2);
+			for (int idx = 0; idx < sb.Length; idx++)
+			{
+				// Double double quotes ("") escape a double quote in a quoted string
+				if (sb[idx] == '"')
+				{
+					// Strip double quote escape
+					sb.Remove(idx, 1);
+					if (idx < sb.Length && sb[idx] == '"')
+					{
+						// Retain escaped double quote
+						idx += 1;
+					}
+					else
+					{
+						// The character after escape is not a double quote, we terminate the conversion and truncate.
+						// Firebird does this as well (see common/utils.cpp#dpbItemUpper)
+						sb.Length = idx;
+						return sb.ToString();
+					}
+				}
+			}
+			return sb.ToString();
 		}
 
 		#endregion

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/SrpClient.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/SrpClient.cs
@@ -59,7 +59,7 @@ namespace FirebirdSql.Data.Client.Managed
 			var n2 = BigIntegerFromByteArray(ComputeHash(BigIntegerToByteArray(g)));
 
 			n1 = BigInteger.ModPow(n1, n2, N);
-			n2 = BigIntegerFromByteArray(ComputeHash(Encoding.UTF8.GetBytes(user.ToUpper())));
+			n2 = BigIntegerFromByteArray(ComputeHash(Encoding.UTF8.GetBytes(user)));
 			var M = ComputeHash(BigIntegerToByteArray(n1), BigIntegerToByteArray(n2), salt, BigIntegerToByteArray(PublicKey), BigIntegerToByteArray(serverPublicKey), K);
 
 			SessionKey = K;
@@ -80,7 +80,7 @@ namespace FirebirdSql.Data.Client.Managed
 			Array.Copy(authData, serverKeyStart, hexServerPublicKey, 0, serverKeyLength);
 			var hexServerPublicKeyString = Encoding.UTF8.GetString(hexServerPublicKey);
 			var serverPublicKey = BigInteger.Parse($"00{hexServerPublicKeyString}", NumberStyles.HexNumber);
-			return ClientProof(user.ToUpper(), password, salt, serverPublicKey);
+			return ClientProof(user, password, salt, serverPublicKey);
 		}
 
 		public Tuple<BigInteger, BigInteger> ServerSeed(string user, string password, byte[] salt)
@@ -133,7 +133,7 @@ namespace FirebirdSql.Data.Client.Managed
 
 		private static BigInteger GetUserHash(string user, string password, byte[] salt)
 		{
-			var userBytes = Encoding.UTF8.GetBytes(user.ToUpper());
+			var userBytes = Encoding.UTF8.GetBytes(user);
 			var passwordBytes = Encoding.UTF8.GetBytes(password);
 			var hash1 = ComputeHash(userBytes, SEPARATOR_BYTES, passwordBytes);
 			var hash2 = ComputeHash(salt, hash1);


### PR DESCRIPTION
Adds support for Firebird 3 case sensitive user names. Case sensitive user names are quoted object names (like table names, column names, etc), that is: they must be enclosed in double quotes. Case sensitive user names support the UNICODE_FSS range of characters (with some exceptions, same as for other object names).

When used in a connection string, make sure to enclose the quoted user names in single quotes, eg `"user id='\"CaseSensitive\"';..."`

Also changes method of uppercasing from `ToUpper()` to `ToUpperInvariant()` to avoid issues due to locale-sensitive uppercasing.