### PR TITLE
add repository type and url to nuspec files

### DIFF
--- a/Provider/nuget/EntityFramework.Firebird/EntityFramework.Firebird.nuspec
+++ b/Provider/nuget/EntityFramework.Firebird/EntityFramework.Firebird.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
 	<metadata>
 		<id>EntityFramework.Firebird</id>
 		<version>0.0.0.0</version>
@@ -9,6 +9,7 @@
 		<owners>FirebirdSQL</owners>
 		<licenseUrl>https://raw.githubusercontent.com/FirebirdSQL/NETProvider/master/license.txt</licenseUrl>
 		<projectUrl>http://www.firebirdsql.org/en/net-provider/</projectUrl>
+		<repository type="git" url="https://github.com/cincuranet/FirebirdSql.Data.FirebirdClient.git" />
 		<iconUrl>http://www.firebirdsql.org/file/about/ds-firebird-logo-64.png</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<tags>firebird firebirsql firebirdclient entityframework adonet database</tags>

--- a/Provider/nuget/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.nuspec
+++ b/Provider/nuget/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
 	<metadata minClientVersion="3.6">
 		<id>FirebirdSql.Data.FirebirdClient</id>
 		<version>0.0.0.0</version>
@@ -9,6 +9,7 @@
 		<owners>FirebirdSQL</owners>
 		<licenseUrl>https://raw.githubusercontent.com/FirebirdSQL/NETProvider/master/license.txt</licenseUrl>
 		<projectUrl>http://www.firebirdsql.org/en/net-provider/</projectUrl>
+		<repository type="git" url="https://github.com/cincuranet/FirebirdSql.Data.FirebirdClient.git" />
 		<iconUrl>http://www.firebirdsql.org/file/about/ds-firebird-logo-64.png</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<tags>firebird firebirsql firebirdclient adonet database</tags>

--- a/Provider/nuget/FirebirdSql.EntityFrameworkCore.Firebird/FirebirdSql.EntityFrameworkCore.Firebird.nuspec
+++ b/Provider/nuget/FirebirdSql.EntityFrameworkCore.Firebird/FirebirdSql.EntityFrameworkCore.Firebird.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-	<metadata>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+	<metadata minClientVersion="3.6">
 		<id>FirebirdSql.EntityFrameworkCore.Firebird</id>
 		<version>0.0.0.0</version>
 		<title>Firebird Entity Framework Core Provider</title>
@@ -9,6 +9,7 @@
 		<owners>FirebirdSQL</owners>
 		<licenseUrl>https://raw.githubusercontent.com/FirebirdSQL/NETProvider/master/license.txt</licenseUrl>
 		<projectUrl>http://www.firebirdsql.org/en/net-provider/</projectUrl>
+		<repository type="git" url="https://github.com/cincuranet/FirebirdSql.Data.FirebirdClient.git" />
 		<iconUrl>http://www.firebirdsql.org/file/about/ds-firebird-logo-64.png</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<tags>firebird firebirsql firebirdclient entityframeworkcore adonet database</tags>


### PR DESCRIPTION
According to the [NuGet blog post about Source Link](https://blog.nuget.org/20180827/Introducing-Source-Code-Link-for-NuGet-packages.html), the entry 

`<repository type="git" url="https://github.com/cincuranet/FirebirdSql.Data.FirebirdClient.git" />`

should be added to the nuspec files, so that NuGet website shows link to source code

![image](https://user-images.githubusercontent.com/8274816/50660925-b4dc5280-0fa1-11e9-9adc-c45d6549ace9.png)
