### PR TITLE
Fix NotImplementedException when using string or byte array fields.

### DIFF
--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbBoolTypeMapping.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbBoolTypeMapping.cs
@@ -28,9 +28,18 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 			: base("BOOLEAN", System.Data.DbType.Boolean)
 		{ }
 
+		private FbBoolTypeMapping(RelationalTypeMappingParameters parameters)
+			: base(parameters)
+		{ }
+
 		protected override string GenerateNonNullSqlLiteral(object value)
 		{
 			return (bool)value ? TrueLiteral : FalseLiteral;
+		}
+
+		protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+		{
+			return new FbBoolTypeMapping(parameters);
 		}
 	}
 }

--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbByteArrayTypeMapping.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbByteArrayTypeMapping.cs
@@ -26,10 +26,19 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 			: base("BLOB SUB_TYPE BINARY", System.Data.DbType.Binary)
 		{ }
 
+		private FbByteArrayTypeMapping(RelationalTypeMappingParameters parameters)
+			: base(parameters)
+		{ }
+
 		protected override string GenerateNonNullSqlLiteral(object value)
 		{
 			var hex = ((byte[])value).ToHexString();
 			return $"x'{hex}'";
+		}
+
+		protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+		{
+			return new FbByteArrayTypeMapping(parameters);
 		}
 	}
 }

--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbDateTimeTypeMapping.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbDateTimeTypeMapping.cs
@@ -32,6 +32,10 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 			_fbDbType = fbDbType;
 		}
 
+		private FbDateTimeTypeMapping(RelationalTypeMappingParameters parameters)
+			: base(parameters)
+		{ }
+
 		protected override void ConfigureParameter(DbParameter parameter)
 		{
 			((FbParameter)parameter).FbDbType = _fbDbType;
@@ -50,6 +54,11 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 				default:
 					throw new ArgumentOutOfRangeException(nameof(_fbDbType), $"{nameof(_fbDbType)}={_fbDbType}");
 			}
+		}
+
+		protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+		{
+			return new FbDateTimeTypeMapping(parameters);
 		}
 	}
 }

--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbGuidTypeMapping.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbGuidTypeMapping.cs
@@ -27,6 +27,10 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 			: base("CHAR(16) CHARACTER SET OCTETS")
 		{ }
 
+		private FbGuidTypeMapping(RelationalTypeMappingParameters parameters)
+			: base(parameters)
+		{ }
+
 		protected override void ConfigureParameter(DbParameter parameter)
 		{
 			((FbParameter)parameter).FbDbType = FbDbType.Guid;
@@ -35,6 +39,11 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 		protected override string GenerateNonNullSqlLiteral(object value)
 		{
 			return $"CHAR_TO_UUID('{value}')";
+		}
+
+		protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+		{
+			return new FbGuidTypeMapping(parameters);
 		}
 	}
 }

--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbStringTypeMapping.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbStringTypeMapping.cs
@@ -31,6 +31,10 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 			_fbDbType = fbDbType;
 		}
 
+		private FbStringTypeMapping(RelationalTypeMappingParameters parameters)
+			: base(parameters)
+		{ }
+
 		protected override void ConfigureParameter(DbParameter parameter)
 		{
 			((FbParameter)parameter).FbDbType = _fbDbType;
@@ -42,6 +46,11 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal
 			return IsUnicode
 				? $"_UTF8'{EscapeSqlLiteral(svalue)}'"
 				: $"'{EscapeSqlLiteral(svalue)}'";
+		}
+
+		protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+		{
+			return new FbStringTypeMapping(parameters);
 		}
 	}
 }


### PR DESCRIPTION
This pull request contains all the changes that were necessary to make our application to work with EF Core.

The `NotImplementedException`s we were running into were thrown [here](https://github.com/aspnet/EntityFrameworkCore/blob/release/2.2/src/EFCore.Relational/Storage/RelationalTypeMapping.cs#L446)

Example exception text:
`System.NotImplementedException:` 'The `FbByteArrayTypeMapping` does not support value conversions. Support for value conversions typically requires changes in the database provider.'

Let me know whether this is the correct fix.