### PR TITLE
Configurable TransactionBehaviors for specific IsolationLevel

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -37,9 +37,11 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net452'">
 		<Reference Include="System.Transactions" />
+		<Reference Include="System.Configuration" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
 	</ItemGroup>
 	<Import Project="..\FirebirdSql.Data.External\FirebirdSql.Data.External.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
With this you can alter the default behavior for the IsolationLevels.
We need this because we use an ORM-Wrapper. So we can't use the constructor with FbTransactionOptions parameter and our code relies on the Wait used back then with FirebirdClient 2.

For example:
```
<?xml version="1.0">
<configuration>
  <configSections>
    <section name="firebirdSettings" type="System.Configuration.NameValueSectionHandler"/>
  </configSections>
  <firebirdSettings>
    <add key="TransactionBehavior.Chaos" value="Wait, ReadCommitted, NoRecVersion"/>
    <add key="TransactionBehavior.ReadCommitted" value="Wait, ReadCommitted, NoRecVersion"/>
  </firebirdSettings>
</configuration>
```