### PR TITLE
explicitly cast formatted date/time values as TIMESTAMP/TIME

### DIFF
--- a/Provider/src/EntityFramework.Firebird/SqlGen/SqlGenerator.cs
+++ b/Provider/src/EntityFramework.Firebird/SqlGen/SqlGenerator.cs
@@ -3143,18 +3143,18 @@ namespace EntityFramework.Firebird.SqlGen
 		internal static string FormatDateTime(DateTime value)
 		{
 			var result = new StringBuilder();
-			result.Append("'");
+			result.Append("CAST('");
 			result.Append(value.ToString("yyyy-MM-dd HH:mm:ss.ffff", CultureInfo.InvariantCulture));
-			result.Append("'");
+			result.Append("' AS TIMESTAMP)");
 			return result.ToString();
 		}
 
 		internal static string FormatTime(DateTime value)
 		{
 			var result = new StringBuilder();
-			result.Append("'");
+			result.Append("CAST('");
 			result.Append(value.ToString("HH:mm:ss.ffff", CultureInfo.InvariantCulture));
-			result.Append("'");
+			result.Append("' AS TIME)");
 			return result.ToString();
 		}
 		internal static string FormatTime(TimeSpan value)


### PR DESCRIPTION
  e.g. for parameters in functions/procedures
  old: DATEDIFF(DAY, CURRENT_TIMESTAMP, '2020-01-02 00:00:00.0000')
  now: DATEDIFF(DAY, CURRENT_TIMESTAMP, CAST('2020-01-02 00:00:00.0000' as TIMESTAMP))

Solves issue http://tracker.firebirdsql.org/browse/DNET-932