### PR TITLE
correct SQL generation for DbFunctions.CreateDateTime

### DIFF
--- a/Provider/src/EntityFramework.Firebird.Tests/QueryTests.cs
+++ b/Provider/src/EntityFramework.Firebird.Tests/QueryTests.cs
@@ -15,6 +15,7 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
+using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
@@ -135,6 +136,65 @@ namespace EntityFramework.Firebird.Tests
 			{
 				var q = c.Bars.Where(x => x.BarString == "TEST");
 				StringAssert.Contains("CAST(_UTF8'TEST' AS VARCHAR(8191))", q.ToString());
+
+			}
+		}
+
+		class DbFunctionsContext : FbTestDbContext
+		{
+			public DbFunctionsContext(FbConnection conn)
+				: base(conn)
+			{ }
+
+			protected override void OnModelCreating(DbModelBuilder modelBuilder)
+			{
+				base.OnModelCreating(modelBuilder);
+			}
+
+			public IDbSet<Qux> Quxs { get; set; }
+		}
+		[Test]
+		public void QueryTestDbFunctionsCreateDateTime1()
+		{
+			using (var c = GetDbContext<DbFunctionsContext>())
+			{
+				var q = c.Quxs
+					.Where(x => x.QuxDateTime == DbFunctions.CreateDateTime(2020, 3, 19, 14, 12, 0))
+					.ToString();
+				StringAssert.Contains("CAST('2020-3-19 14:12:00' AS TIMESTAMP)", q.ToString());
+			}
+		}
+		[Test]
+		public void QueryTestDbFunctionsCreateDateTime2()
+		{
+			using (var c = GetDbContext<DbFunctionsContext>())
+			{
+				var q = c.Quxs
+					.Where(x => x.QuxDateTime == DbFunctions.CreateDateTime(2020, 3, 19, 14, 12, 36))
+					.ToString();
+				StringAssert.Contains("DATEADD(SECOND,CAST(36 AS DOUBLE PRECISION),CAST('2020-3-19 14:12:00' AS TIMESTAMP))", q.ToString());
+			}
+		}
+		[Test]
+		public void QueryTestDbFunctionsCreateDateTime3()
+		{
+			using (var c = GetDbContext<DbFunctionsContext>())
+			{
+				var q = c.Quxs
+					.Where(x => x.QuxDateTime == DbFunctions.CreateDateTime(null, null, null, null, null, null))
+					.ToString();
+				StringAssert.Contains("DATEADD(DAY,-1,DATEADD(MONTH,-1,DATEADD(YEAR,-1,CAST('0001-01-01 00:00:00' AS TIMESTAMP))))", q.ToString());
+			}
+		}
+		[Test]
+		public void QueryTestDbFunctionsCreateDateTime4()
+		{
+			using (var c = GetDbContext<DbFunctionsContext>())
+			{
+				var q = c.Quxs
+					.Where(x => x.QuxDateTime == DbFunctions.CreateDateTime(x.QuxYear, x.QuxMonth, x.QuxDay, null, null, null))
+					.ToString();
+				StringAssert.Contains("DATEADD(DAY,-1,DATEADD(MONTH,-1,DATEADD(YEAR,-1,DATEADD(DAY,\"B\".\"QuxDay\",DATEADD(MONTH,\"B\".\"QuxMonth\",DATEADD(YEAR,\"B\".\"QuxYear\",CAST('0001-01-01 00:00:00' AS TIMESTAMP)))))))", q.ToString());
 			}
 		}
 	}
@@ -163,5 +223,13 @@ namespace EntityFramework.Firebird.Tests
 		public int ID { get; set; }
 		public string BazString { get; set; }
 		public ICollection<Foo> Foos { get; set; }
+	}
+	class Qux
+	{
+		public int ID { get; set; }
+		public DateTime QuxDateTime { get; set; }
+		public int QuxYear { get; set; }
+		public int QuxMonth { get; set; }
+		public int QuxDay { get; set; }
 	}
 }

--- a/Provider/src/EntityFramework.Firebird.Tests/QueryTests.cs
+++ b/Provider/src/EntityFramework.Firebird.Tests/QueryTests.cs
@@ -172,7 +172,7 @@ namespace EntityFramework.Firebird.Tests
 				var q = c.Quxs
 					.Where(x => x.QuxDateTime == DbFunctions.CreateDateTime(2020, 3, 19, 14, 12, 36))
 					.ToString();
-				StringAssert.Contains("DATEADD(SECOND,CAST(36 AS DOUBLE PRECISION),CAST('2020-3-19 14:12:00' AS TIMESTAMP))", q.ToString());
+				StringAssert.Contains("DATEADD(SECOND, CAST(36 AS DOUBLE PRECISION), CAST('2020-3-19 14:12:00' AS TIMESTAMP))", q.ToString());
 			}
 		}
 		[Test]
@@ -183,7 +183,7 @@ namespace EntityFramework.Firebird.Tests
 				var q = c.Quxs
 					.Where(x => x.QuxDateTime == DbFunctions.CreateDateTime(null, null, null, null, null, null))
 					.ToString();
-				StringAssert.Contains("DATEADD(DAY,-1,DATEADD(MONTH,-1,DATEADD(YEAR,-1,CAST('0001-01-01 00:00:00' AS TIMESTAMP))))", q.ToString());
+				StringAssert.Contains("DATEADD(DAY, -1, DATEADD(MONTH, -1, DATEADD(YEAR, -1, CAST('0001-01-01 00:00:00' AS TIMESTAMP))))", q.ToString());
 			}
 		}
 		[Test]
@@ -194,7 +194,7 @@ namespace EntityFramework.Firebird.Tests
 				var q = c.Quxs
 					.Where(x => x.QuxDateTime == DbFunctions.CreateDateTime(x.QuxYear, x.QuxMonth, x.QuxDay, null, null, null))
 					.ToString();
-				StringAssert.Contains("DATEADD(DAY,-1,DATEADD(MONTH,-1,DATEADD(YEAR,-1,DATEADD(DAY,\"B\".\"QuxDay\",DATEADD(MONTH,\"B\".\"QuxMonth\",DATEADD(YEAR,\"B\".\"QuxYear\",CAST('0001-01-01 00:00:00' AS TIMESTAMP)))))))", q.ToString());
+				StringAssert.Contains("DATEADD(DAY, -1, DATEADD(MONTH, -1, DATEADD(YEAR, -1, DATEADD(DAY, \"B\".\"QuxDay\", DATEADD(MONTH, \"B\".\"QuxMonth\", DATEADD(YEAR, \"B\".\"QuxYear\", CAST('0001-01-01 00:00:00' AS TIMESTAMP)))))))", q.ToString());
 			}
 		}
 	}

--- a/Provider/src/EntityFramework.Firebird/SqlGen/SqlGenerator.cs
+++ b/Provider/src/EntityFramework.Firebird/SqlGen/SqlGenerator.cs
@@ -2676,7 +2676,7 @@ namespace EntityFramework.Firebird.SqlGen
 				result = HandleDateAdd("HOUR", e.Arguments[3].Accept(sqlgen), result);
 			if (e.Arguments[4].ExpressionKind != DbExpressionKind.Constant && e.Arguments[4].ExpressionKind != DbExpressionKind.Null)
 				result = HandleDateAdd("MINUTE", e.Arguments[4].Accept(sqlgen), result);
-			if ((e.Arguments[5].ExpressionKind != DbExpressionKind.Constant || (((DbConstantExpression)e.Arguments[5]).Value as double?)!=0) && e.Arguments[5].ExpressionKind != DbExpressionKind.Null)
+			if ((e.Arguments[5].ExpressionKind != DbExpressionKind.Constant || (((DbConstantExpression)e.Arguments[5]).Value as double?) != 0) && e.Arguments[5].ExpressionKind != DbExpressionKind.Null)
 				result = HandleDateAdd("SECOND", e.Arguments[5].Accept(sqlgen), result);
 
 			// in case a default value was used for the year/month/day part, remove it afterwards
@@ -2695,9 +2695,9 @@ namespace EntityFramework.Firebird.SqlGen
 			SqlBuilder result = new SqlBuilder();
 			result.Append("DATEADD(");
 			result.Append(datePart);
-			result.Append(",");
+			result.Append(", ");
 			result.Append(value);
-			result.Append(",");
+			result.Append(", ");
 			result.Append(dateTime);
 			result.Append(")");
 			return result;


### PR DESCRIPTION
- considers null values
- considers non-constant values (e.g. column references or function calls)
- considers data-type double for seconds

Solves http://tracker.firebirdsql.org/browse/DNET-937