### PR TITLE
Pool concurrency

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionPoolManager.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionPoolManager.cs
@@ -20,6 +20,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using FirebirdSql.Data.Common;
 
 namespace FirebirdSql.Data.FirebirdClient
@@ -123,7 +124,7 @@ namespace FirebirdSql.Data.FirebirdClient
 						keep = keep.Concat(available.Except(keep).OrderByDescending(x => x.Created).Take(_connectionString.MinPoolSize - keepCount)).ToList();
 					}
 					var release = available.Except(keep).ToList();
-					release.AsParallel().ForAll(x => x.Dispose());
+					Parallel.ForEach(release, p => p.Dispose());
 					_available = new Stack<Item>(keep);
 				}
 			}
@@ -207,7 +208,7 @@ namespace FirebirdSql.Data.FirebirdClient
 		{
 			CheckDisposed();
 
-			_pools.Values.AsParallel().ForAll(p => p.ClearPool());
+			Parallel.ForEach(_pools.Values, p => p.ClearPool());
 		}
 
 		internal void ClearPool(ConnectionString connectionString)
@@ -229,12 +230,12 @@ namespace FirebirdSql.Data.FirebirdClient
 				_cleanupTimer.Dispose(mre);
 				mre.WaitOne();
 			}
-			_pools.Values.AsParallel().ForAll(x => x.Dispose());
+			Parallel.ForEach(_pools.Values, p => p.Dispose());
 		}
 
 		void CleanupCallback(object o)
 		{
-			_pools.Values.AsParallel().ForAll(x => x.CleanupPool());
+			Parallel.ForEach(_pools.Values, p => p.CleanupPool());
 		}
 
 		void CheckDisposed()


### PR DESCRIPTION
With the latest version I have blocking problems when using multiple slower connections in async code against a remote database. No cpu cycles are consumed, but code blocks for a long time even in the UI thread (when disposing a connection there).

The changes fix these problems for me. The simple test program improved from

> times for OpenAsync(): min 0,3; average 2295,2; max 5020,6
> times for Dispose(): min 0,0; average 3557,3; max 13699,5

to

> times for OpenAsync(): min 0,0; average 384,3; max 561,6
> times for Dispose(): min 0,0; average 0,2; max 5,1

(all times in ms, using .NET Framework 4.8 on a XEON 6-core with H/T).

    using System;
    using System.Collections.Generic;
    using System.Linq;
    using System.Threading.Tasks;

    namespace ConsoleApp1
    {
        class Program
        {
            // any remote database over a slow connection, 50 MBaud DSL for me
            private static string connectionString = "...";

            static void Main(string[] args)
            {
                Func<Action, double> timeIt = (action) =>
                {
                    var sw = System.Diagnostics.Stopwatch.StartNew();
                    action();
                    return sw.Elapsed.TotalMilliseconds;
                };

                try
                {
                    var tasks = new List<Task<Tuple<double, double>>>();
                    for (var i = 0; i < 50; ++i)
                    {
                        tasks.Add(Task.Run(async () =>
                        {
                            var connection = new FirebirdSql.Data.FirebirdClient.FbConnection(connectionString);
                            var openAsyncDuration = timeIt(async () => await connection.OpenAsync());
                            using (connection.BeginTransaction())
                            {
                                await Task.Delay(500);
                            }
                            var disposeDuration = timeIt(() => connection.Dispose());
                            return new Tuple<double, double>(openAsyncDuration, disposeDuration);
                        }));
                    }
                    Task.WaitAll(tasks.ToArray());

                    var durations = tasks.Select(t => t.Result).ToList();
                    Console.WriteLine("times for OpenAsync(): min {0:0.0}; average {1:0.0}; max {2:0.0}",
                        durations.Min(t => t.Item1), durations.Average(t => t.Item1), durations.Max(t => t.Item1));
                    Console.WriteLine("times for Dispose(): min {0:0.0}; average {1:0.0}; max {2:0.0}",
                        durations.Min(t => t.Item2), durations.Average(t => t.Item2), durations.Max(t => t.Item2));
                }
                catch (Exception ex) { Console.WriteLine(ex); }
            }
        }
    }
