### PR TITLE
Fix DNET-998

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionPoolManager.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionPoolManager.cs
@@ -91,7 +91,15 @@ namespace FirebirdSql.Data.FirebirdClient
 				}
 				if (createdNew)
 				{
-					connection.Connect();
+					try
+					{
+						connection.Connect();
+					}
+					catch (Exception)
+					{
+						_busy.Remove(connection);
+						throw;
+					}
 				}
 				connection.SetOwningConnection(owner);
 				return connection;

--- a/Provider/src/Perf/CommandBenchmark.cs
+++ b/Provider/src/Perf/CommandBenchmark.cs
@@ -33,7 +33,7 @@ namespace Perf
 			public Config()
 			{
 				var baseJob = Job.Default
-					.WithToolchain(CsProjCoreToolchain.NetCoreApp31)
+					.WithToolchain(CsProjCoreToolchain.NetCoreApp50)
 					.WithPlatform(Platform.X64)
 					.WithJit(Jit.RyuJit);
 				AddDiagnoser(MemoryDiagnoser.Default);

--- a/Provider/src/Perf/Perf.csproj
+++ b/Provider/src/Perf/Perf.csproj
@@ -3,6 +3,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net5.0</TargetFramework>
 		<SkipSourceLink>true</SkipSourceLink>
+		<LangVersion>7.3</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
@@ -19,6 +20,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(Configuration.EndsWith('NuGet'))">
-		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
+		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.10.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes the issue that the connection pool was seemingly getting full very quickly, after connection to the database has been lost. The created connections were put in the busy list, as expected. If, however, the created connection could not be connected to the database, it would remain in the collection of busy connection