### PR TITLE
Adds Microsoft.NET.Test.Sdk and NUnit3TestAdapter to NUnit projects.

### DIFF
--- a/src/EntityFramework.Firebird.Tests/EntityFramework.Firebird.Tests.csproj
+++ b/src/EntityFramework.Firebird.Tests/EntityFramework.Firebird.Tests.csproj
@@ -15,7 +15,9 @@
 		<None Remove="app.config" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="NUnitLite" Version="3.13.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/FirebirdSql.Data.FirebirdClient.Tests/FirebirdSql.Data.FirebirdClient.Tests.csproj
+++ b/src/FirebirdSql.Data.FirebirdClient.Tests/FirebirdSql.Data.FirebirdClient.Tests.csproj
@@ -12,7 +12,9 @@
 		<StartupObject>FirebirdSql.Data.TestsBase.Program</StartupObject>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="NUnitLite" Version="3.13.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird.FunctionalTests/FirebirdSql.EntityFrameworkCore.Firebird.FunctionalTests.csproj
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird.FunctionalTests/FirebirdSql.EntityFrameworkCore.Firebird.FunctionalTests.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="6.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 		  <PrivateAssets>all</PrivateAssets>

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird.Tests/FirebirdSql.EntityFrameworkCore.Firebird.Tests.csproj
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird.Tests/FirebirdSql.EntityFrameworkCore.Firebird.Tests.csproj
@@ -12,7 +12,9 @@
 		<StartupObject>FirebirdSql.Data.TestsBase.Program</StartupObject>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="NUnitLite" Version="3.13.3" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
1. **Adds missing packages for NUnit-based tests.**
    When running tests in Visual Studio 2022 only xUnit-based tests work. 
    
    Sources: [here](https://stackoverflow.com/a/74467458/33244) and [here](https://stackoverflow.com/a/67433575/33244).

2. **Upgrades Microsoft.NET.Test.Sdk to version 17.6.3**