### PR TITLE
Uses $env:TEMP folder instead of hardcoded.

### DIFF
--- a/tests.ps1
+++ b/tests.ps1
@@ -37,7 +37,7 @@ if ($env:tests_firebird_dir) {
 	$firebirdDir = $env:tests_firebird_dir
 }
 else {
-	$firebirdDir = 'I:\Downloads\fb_tests'
+	$firebirdDir = "$env:TEMP\fb_tests\$FirebirdSelection\"
 }
 
 function Prepare() {


### PR DESCRIPTION
1. **Make it easier for new users to run tests.**
    Uses `$env:TEMP\fb_tests\$FirebirdSelection\` instead of `I:\Downloads\fb_tests`. 

    This hardcoded default, together with a silent exception being throw (see [further PR](https://github.com/cincuranet/FirebirdSql.Data.FirebirdClient/pull/118)) made it very hard for me to understand what was happening until I debug the script.

