### PR TITLE
Makes downloads with Invoke-RestMethod faster.

### DIFF
--- a/tests.ps1
+++ b/tests.ps1
@@ -4,6 +4,8 @@ param(
 	[Parameter(Mandatory=$True)]$TestSuite)
 
 $ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue' # Faster downloads with Invoke-RestMethod -- https://stackoverflow.com/a/43477248/33244
+
 
 $baseDir = Split-Path -Parent $PSCommandPath
 


### PR DESCRIPTION
1. **Makes the download of Firebird binaries much faster.**
    Due to a [bad implementation](https://stackoverflow.com/a/43477248/33244) of progress in `Invoke-RestMethod`.
