### PR TITLE
Adds tasks for Invoke-Build.

### DIFF
--- a/FirebirdSql.Data.FirebirdClient.build.ps1
+++ b/FirebirdSql.Data.FirebirdClient.build.ps1
@@ -1,0 +1,62 @@
+#
+# FirebirdSql.Data.FirebirdClient Tasks for Invoke-Build
+#
+# Requires Invoke-Build -- https://github.com/nightroman/Invoke-Build
+#
+#   dotnet tool install --global ib
+#
+
+param(
+    $Configuration = 'Debug',
+    $VersionSuffix = $null
+)
+
+
+#
+# Globals
+#
+
+$baseDir = Split-Path -Parent $PSCommandPath
+$outDir = "$baseDir\out"
+$version = ''
+
+$solutionFile = "$baseDir\src\NETProvider.sln"
+
+
+#
+# Tasks
+#
+
+task Clean {
+    # Remove output folder
+    Remove-Item $outDir -Recurse -Force -ErrorAction SilentlyContinue
+	mkdir $outDir | Out-Null
+
+    # Remove binaries + nuget packages
+    Exec { dotnet msbuild /t:Clean /p:Configuration=$Configuration /p:ContinuousIntegrationBuild=true $solutionFile /v:m /m }
+
+    # Remove nuget packages
+    Get-ChildItem "$baseDir\src\*\bin\$Configuration" -Include '*.nupkg','*.snupkg' -Recurse | 
+        Remove-Item -Force -ErrorAction SilentlyContinue
+}
+
+task Build Clean, {
+    # This sometimes fails on CI (call without Exec = do not check for exit code)
+    dotnet msbuild /t:Restore /p:Configuration=$Configuration /p:ContinuousIntegrationBuild=true $solutionFile /v:m /m
+
+    Exec { dotnet msbuild /t:Restore /p:Configuration=$Configuration /p:ContinuousIntegrationBuild=true $solutionFile /v:m /m }
+
+    # Build binaries + nuget packages
+    Exec { dotnet msbuild /t:Build /p:Configuration=$Configuration /p:ContinuousIntegrationBuild=true $solutionFile /v:m /m /p:VERSIONSUFFIX=$VersionSuffix }
+
+    # Copy nuget packages to output folder
+    Get-ChildItem "$baseDir\src\*\bin\$Configuration" -Include '*.nupkg','*.snupkg' -Recurse | 
+        Copy-Item -Destination $outDir
+}
+
+
+#
+# Default task
+#
+
+task . Build


### PR DESCRIPTION
Port of `build.ps1` script to [`Invoke-Build`](https://github.com/nightroman/Invoke-Build/wiki).  Tell me what you think. If you did like I will port the other scripts.

To use it, just install `Invoke-Build` with

`dotnet tool install --global ib`

And call it with:

1.
    ```powershell
    ib
    ```
    equivalent to `.\build.ps1 -Configuration Debug`

2.
    ```powershell
    ib -Configuration Release
    ```
    equivalent to `.\build.ps1 -Configuration Release`

3. I also added a new `-VersionSuffix` parameter (optional). So it is now possible to build nuget packages with a specific version without changing `Directory.Build.props`. E.g.: 
    ```powershell
    ib -Configuration Release -VersionSuffix alpha2
    ```
