### PR TITLE
RFC: Reduce memory allocations [Do not merge]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 obj
 out/
 .idea
+/BenchmarkDotNet.Artifacts

--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -1,0 +1,11 @@
+param(
+	[Parameter(Mandatory=$True)]$Benchmark = 'CommandBenchmark'
+)
+
+$ErrorActionPreference = 'Stop'
+
+
+
+dotnet build .\src\Perf\Perf.csproj --configuration 'Release'
+& .\src\Perf\bin\Release\net7.0\Perf.exe --filter "*$($Benchmark)*"
+

--- a/download-firebird-binaries.ps1
+++ b/download-firebird-binaries.ps1
@@ -1,0 +1,5 @@
+$binariesFolder = "$env:TEMP/firebird-binaries"
+
+# Download Firebird binaries
+Remove-Item $binariesFolder -Recurse -Force -ErrorAction SilentlyContinue
+git clone --quiet --depth 1 --single-branch https://github.com/fdcastel/firebird-binaries $binariesFolder

--- a/src/EntityFramework.Firebird/EntityFramework.Firebird.csproj
+++ b/src/EntityFramework.Firebird/EntityFramework.Firebird.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1</TargetFrameworks>
 		<AssemblyName>EntityFramework.Firebird</AssemblyName>
 		<RootNamespace>EntityFramework.Firebird</RootNamespace>
 		<SignAssembly>true</SignAssembly>

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/DataProviderStreamWrapper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/DataProviderStreamWrapper.cs
@@ -15,6 +15,7 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -43,10 +44,23 @@ sealed class DataProviderStreamWrapper : IDataProvider
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Write(ReadOnlySpan<byte> buffer)
+	{
+		_stream.Write(buffer);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Write(byte[] buffer, int offset, int count)
 	{
 		_stream.Write(buffer, offset, count);
 	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+	{
+		await _stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+	}
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ValueTask WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
 	{

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
@@ -144,8 +144,7 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 	public void Flush()
 	{
 		var buffer = _outputBuffer.ToArray();
-		Array.Clear(buffer, 0, buffer.Length);
-		_outputBuffer.Position = 0;
+		_outputBuffer.SetLength(0);
 		var count = buffer.Length;
 		if (_compressor != null)
 		{
@@ -170,8 +169,7 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 	public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
 	{
 		var buffer = _outputBuffer.ToArray();
-		Array.Clear(buffer, 0, buffer.Length);
-		_outputBuffer.Position = 0;
+		_outputBuffer.SetLength(0);
 		var count = buffer.Length;
 		if (_compressor != null)
 		{

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IDataProvider.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IDataProvider.cs
@@ -15,6 +15,7 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,7 +26,10 @@ interface IDataProvider
 	int Read(byte[] buffer, int offset, int count);
 	ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default);
 
+	void Write(ReadOnlySpan<byte> buffer);
 	void Write(byte[] buffer, int offset, int count);
+
+	ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default);
 	ValueTask WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default);
 
 	void Flush();

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version10/GdsStatement.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version10/GdsStatement.cs
@@ -399,7 +399,7 @@ internal class GdsStatement : StatementBase
 			{
 				_database.Xdr.Write(IscCodes.op_fetch);
 				_database.Xdr.Write(_handle);
-				_database.Xdr.WriteBuffer(_fields.ToBlr());
+				_database.Xdr.WriteBuffer(_fields.ToBlrSpan());
 				_database.Xdr.Write(0); // p_sqldata_message_number
 				_database.Xdr.Write(_fetchSize); // p_sqldata_messages
 				_database.Xdr.Flush();
@@ -781,7 +781,7 @@ internal class GdsStatement : StatementBase
 
 		if (_parameters != null)
 		{
-			_database.Xdr.WriteBuffer(_parameters.ToBlr());
+			_database.Xdr.WriteBuffer(_parameters.ToBlrSpan());
 			_database.Xdr.Write(0); // Message number
 			_database.Xdr.Write(1); // Number of messages
 			_database.Xdr.WriteBytes(parametersData, parametersData.Length);
@@ -798,7 +798,7 @@ internal class GdsStatement : StatementBase
 			_database.Xdr.WriteBuffer(
 				_fields is null
 					? ReadOnlySpan<byte>.Empty
-					: _fields.ToBlr()
+					: _fields.ToBlrSpan()
 			);
 
 			_database.Xdr.Write(0); // Output message number

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version10/GdsStatement.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version10/GdsStatement.cs
@@ -399,7 +399,7 @@ internal class GdsStatement : StatementBase
 			{
 				_database.Xdr.Write(IscCodes.op_fetch);
 				_database.Xdr.Write(_handle);
-				_database.Xdr.WriteBuffer(_fields.ToBlr().Data);
+				_database.Xdr.WriteBuffer(_fields.ToBlr());
 				_database.Xdr.Write(0); // p_sqldata_message_number
 				_database.Xdr.Write(_fetchSize); // p_sqldata_messages
 				_database.Xdr.Flush();
@@ -480,7 +480,7 @@ internal class GdsStatement : StatementBase
 			{
 				await _database.Xdr.WriteAsync(IscCodes.op_fetch, cancellationToken).ConfigureAwait(false);
 				await _database.Xdr.WriteAsync(_handle, cancellationToken).ConfigureAwait(false);
-				await _database.Xdr.WriteBufferAsync(_fields.ToBlr().Data, cancellationToken).ConfigureAwait(false);
+				await _database.Xdr.WriteBufferAsync(_fields.ToBlrMemory(), cancellationToken).ConfigureAwait(false);
 				await _database.Xdr.WriteAsync(0, cancellationToken).ConfigureAwait(false); // p_sqldata_message_number
 				await _database.Xdr.WriteAsync(_fetchSize, cancellationToken).ConfigureAwait(false); // p_sqldata_messages
 				await _database.Xdr.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -781,7 +781,7 @@ internal class GdsStatement : StatementBase
 
 		if (_parameters != null)
 		{
-			_database.Xdr.WriteBuffer(_parameters.ToBlr().Data);
+			_database.Xdr.WriteBuffer(_parameters.ToBlr());
 			_database.Xdr.Write(0); // Message number
 			_database.Xdr.Write(1); // Number of messages
 			_database.Xdr.WriteBytes(parametersData, parametersData.Length);
@@ -795,7 +795,12 @@ internal class GdsStatement : StatementBase
 
 		if (StatementType == DbStatementType.StoredProcedure)
 		{
-			_database.Xdr.WriteBuffer(_fields?.ToBlr().Data);
+			_database.Xdr.WriteBuffer(
+				_fields is null
+					? ReadOnlySpan<byte>.Empty
+					: _fields.ToBlr()
+			);
+
 			_database.Xdr.Write(0); // Output message number
 		}
 	}
@@ -818,7 +823,7 @@ internal class GdsStatement : StatementBase
 
 		if (_parameters != null)
 		{
-			await _database.Xdr.WriteBufferAsync(_parameters.ToBlr().Data, cancellationToken).ConfigureAwait(false);
+			await _database.Xdr.WriteBufferAsync(_parameters.ToBlrMemory(), cancellationToken).ConfigureAwait(false);
 			await _database.Xdr.WriteAsync(0, cancellationToken).ConfigureAwait(false); // Message number
 			await _database.Xdr.WriteAsync(1, cancellationToken).ConfigureAwait(false); // Number of messages
 			await _database.Xdr.WriteBytesAsync(parametersData, parametersData.Length, cancellationToken).ConfigureAwait(false);
@@ -832,7 +837,12 @@ internal class GdsStatement : StatementBase
 
 		if (StatementType == DbStatementType.StoredProcedure)
 		{
-			await _database.Xdr.WriteBufferAsync(_fields?.ToBlr().Data, cancellationToken).ConfigureAwait(false);
+			await _database.Xdr.WriteBufferAsync(
+				_fields is null
+					? ReadOnlyMemory<byte>.Empty
+					: _fields.ToBlrMemory(),
+				cancellationToken
+			).ConfigureAwait(false);
 			await _database.Xdr.WriteAsync(0, cancellationToken).ConfigureAwait(false); // Output message number
 		}
 	}

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version16/GdsBatch.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version16/GdsBatch.cs
@@ -44,7 +44,7 @@ internal class GdsBatch : BatchBase
 		Database.Xdr.Write(IscCodes.op_batch_create);
 		Database.Xdr.Write(_statement.Handle); // p_batch_statement
 		var blr = _statement.Parameters.ToBlr();
-		Database.Xdr.WriteBuffer(blr.Data); // p_batch_blr
+		Database.Xdr.WriteBuffer(blr); // p_batch_blr
 		Database.Xdr.Write(blr.Length); // p_batch_msglen
 		var pb = _statement.CreateBatchParameterBuffer();
 		if (_statement.ReturnRecordsAffected)
@@ -96,8 +96,8 @@ internal class GdsBatch : BatchBase
 
 		await Database.Xdr.WriteAsync(IscCodes.op_batch_create, cancellationToken).ConfigureAwait(false);
 		await Database.Xdr.WriteAsync(_statement.Handle, cancellationToken).ConfigureAwait(false); // p_batch_statement
-		var blr = _statement.Parameters.ToBlr();
-		await Database.Xdr.WriteBufferAsync(blr.Data, cancellationToken).ConfigureAwait(false); // p_batch_blr
+		var blr = _statement.Parameters.ToBlrMemory();
+		await Database.Xdr.WriteBufferAsync(blr, cancellationToken).ConfigureAwait(false); // p_batch_blr
 		await Database.Xdr.WriteAsync(blr.Length, cancellationToken).ConfigureAwait(false); // p_batch_msglen
 		var pb = _statement.CreateBatchParameterBuffer();
 		if (_statement.ReturnRecordsAffected)

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version16/GdsBatch.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version16/GdsBatch.cs
@@ -43,9 +43,9 @@ internal class GdsBatch : BatchBase
 
 		Database.Xdr.Write(IscCodes.op_batch_create);
 		Database.Xdr.Write(_statement.Handle); // p_batch_statement
-		var blr = _statement.Parameters.ToBlr();
+		var blr = _statement.Parameters.ToBlrSpan(out var blrMsgLen);
 		Database.Xdr.WriteBuffer(blr); // p_batch_blr
-		Database.Xdr.Write(blr.Length); // p_batch_msglen
+		Database.Xdr.Write(blrMsgLen); // p_batch_msglen
 		var pb = _statement.CreateBatchParameterBuffer();
 		if (_statement.ReturnRecordsAffected)
 		{
@@ -96,9 +96,9 @@ internal class GdsBatch : BatchBase
 
 		await Database.Xdr.WriteAsync(IscCodes.op_batch_create, cancellationToken).ConfigureAwait(false);
 		await Database.Xdr.WriteAsync(_statement.Handle, cancellationToken).ConfigureAwait(false); // p_batch_statement
-		var blr = _statement.Parameters.ToBlrMemory();
+		var blr = _statement.Parameters.ToBlrMemory(out var blrMsgLen);
 		await Database.Xdr.WriteBufferAsync(blr, cancellationToken).ConfigureAwait(false); // p_batch_blr
-		await Database.Xdr.WriteAsync(blr.Length, cancellationToken).ConfigureAwait(false); // p_batch_msglen
+		await Database.Xdr.WriteAsync(blrMsgLen, cancellationToken).ConfigureAwait(false); // p_batch_msglen
 		var pb = _statement.CreateBatchParameterBuffer();
 		if (_statement.ReturnRecordsAffected)
 		{

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLDA.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLDA.cs
@@ -29,3 +29,12 @@ internal struct XSQLDA
 	public short sqln;
 	public short sqld;
 }
+
+internal unsafe struct XSQLDA_STRUCT
+{
+	public short version;
+	public fixed byte sqldaid[8];
+	public int sqldabc;
+	public short sqln;
+	public short sqld;
+}

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLDA.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLDA.cs
@@ -15,20 +15,7 @@
 
 //$Authors = Carlos Guzman Alvarez, Jiri Cincura (jiri@cincura.net)
 
-using System.Runtime.InteropServices;
-
 namespace FirebirdSql.Data.Client.Native.Marshalers;
-
-[StructLayout(LayoutKind.Sequential)]
-internal struct XSQLDA
-{
-	public short version;
-	[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 8)]
-	public string sqldaid;
-	public int sqldabc;
-	public short sqln;
-	public short sqld;
-}
 
 internal unsafe struct XSQLDA_STRUCT
 {

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLVAR.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLVAR.cs
@@ -42,3 +42,21 @@ internal class XSQLVAR
 	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
 	public byte[] aliasname;
 }
+
+internal unsafe struct XSQLVAR_STRUCT
+{
+	public short sqltype;
+	public short sqlscale;
+	public short sqlsubtype;
+	public short sqllen;
+	public IntPtr sqldata;
+	public IntPtr sqlind;
+	public short sqlname_length;
+	public fixed byte sqlname[32];
+	public short relname_length;
+	public fixed byte relname[32];
+	public short ownername_length;
+	public fixed byte ownername[32];
+	public short aliasname_length;
+	public fixed byte aliasname[32];
+}

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLVAR.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLVAR.cs
@@ -16,32 +16,8 @@
 //$Authors = Carlos Guzman Alvarez, Jiri Cincura (jiri@cincura.net)
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace FirebirdSql.Data.Client.Native.Marshalers;
-
-[StructLayout(LayoutKind.Sequential)]
-internal class XSQLVAR
-{
-	public short sqltype;
-	public short sqlscale;
-	public short sqlsubtype;
-	public short sqllen;
-	public IntPtr sqldata;
-	public IntPtr sqlind;
-	public short sqlname_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] sqlname;
-	public short relname_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] relname;
-	public short ownername_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] ownername;
-	public short aliasname_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] aliasname;
-}
 
 internal unsafe struct XSQLVAR_STRUCT
 {

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XsqldaMarshaler.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XsqldaMarshaler.cs
@@ -78,7 +78,6 @@ internal static class XsqldaMarshaler
 				sqllen = descriptor[i].Length
 			};
 
-
 			if (descriptor[i].HasDataType() && descriptor[i].DbDataType != DbDataType.Null)
 			{
 				var buffer = descriptor[i].DbValue.GetBytes();
@@ -106,11 +105,6 @@ internal static class XsqldaMarshaler
 			xsqlvar[i].aliasname_length = (short)descriptor[i].Alias.Length;
 		}
 
-		return MarshalManagedToNative(xsqlda, xsqlvar);
-	}
-
-	public static IntPtr MarshalManagedToNative(XSQLDA xsqlda, XSQLVAR[] xsqlvar)
-	{
 		var size = ComputeLength(xsqlda.sqln);
 		var ptr = Marshal.AllocHGlobal(size);
 
@@ -164,7 +158,7 @@ internal static class XsqldaMarshaler
 	private unsafe static int ComputeLength(int n) =>
 		sizeof(XSQLDA_STRUCT) + (n * sizeof(XSQLVAR_STRUCT)) + (IntPtr.Size == 8 ? 4 : 0);
 
-	private static byte[] GetBytes(ref XSQLVAR_STRUCT xsqlvar)
+	private unsafe static ReadOnlySpan<byte> GetBytes(ref XSQLVAR_STRUCT xsqlvar)
 	{
 		if (xsqlvar.sqllen == 0 || xsqlvar.sqldata == IntPtr.Zero)
 		{
@@ -176,10 +170,9 @@ internal static class XsqldaMarshaler
 		{
 			case IscCodes.SQL_VARYING:
 				{
-					var buffer = new byte[Marshal.ReadInt16(xsqlvar.sqldata)];
-					var tmp = IntPtr.Add(xsqlvar.sqldata, 2);
-					Marshal.Copy(tmp, buffer, 0, buffer.Length);
-					return buffer;
+					var length = Marshal.ReadInt16(xsqlvar.sqldata);
+					var pointer = IntPtr.Add(xsqlvar.sqldata, 2).ToPointer();
+					return new ReadOnlySpan<byte>(pointer, length);
 				}
 			case IscCodes.SQL_TEXT:
 			case IscCodes.SQL_SHORT:
@@ -203,9 +196,9 @@ internal static class XsqldaMarshaler
 			case IscCodes.SQL_DEC34:
 			case IscCodes.SQL_INT128:
 				{
-					var buffer = new byte[xsqlvar.sqllen];
-					Marshal.Copy(xsqlvar.sqldata, buffer, 0, buffer.Length);
-					return buffer;
+					var length = xsqlvar.sqllen;
+					var pointer = xsqlvar.sqldata.ToPointer();
+					return new ReadOnlySpan<byte>(pointer, length);
 				}
 			default:
 				throw TypeHelper.InvalidDataType(type);

--- a/src/FirebirdSql.Data.FirebirdClient/Common/Descriptor.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/Descriptor.cs
@@ -98,12 +98,13 @@ internal sealed class Descriptor
 		}
 	}
 
-	public ReadOnlyMemory<byte> ToBlrMemory()
+	public ReadOnlyMemory<byte> ToBlrMemory() => ToBlrMemory(out int _);
+
+	public ReadOnlyMemory<byte> ToBlrMemory(out int length)
 	{
+		length = 0;
 		using (var blr = new MemoryStream(256))
 		{
-			var length = 0;
-
 			blr.WriteByte(IscCodes.blr_version5);
 			blr.WriteByte(IscCodes.blr_begin);
 			blr.WriteByte(IscCodes.blr_message);
@@ -281,10 +282,14 @@ internal sealed class Descriptor
 			blr.WriteByte(IscCodes.blr_end);
 			blr.WriteByte(IscCodes.blr_eoc);
 
-			return new ReadOnlyMemory<byte>(blr.GetBuffer(), 0, length);
+			var buf = blr.GetBuffer();
+			return new ReadOnlyMemory<byte>(buf, 0, buf.Length);
 		}
 	}
 
-	public ReadOnlySpan<byte> ToBlr() => ToBlrMemory().Span;
+	public ReadOnlySpan<byte> ToBlrSpan() => ToBlrMemory(out int _).Span;
+
+	public ReadOnlySpan<byte> ToBlrSpan(out int length) => ToBlrMemory(out length).Span;
+
 	#endregion
 }

--- a/src/FirebirdSql.Data.FirebirdClient/Common/Descriptor.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/Descriptor.cs
@@ -98,18 +98,7 @@ internal sealed class Descriptor
 		}
 	}
 
-	internal sealed class BlrData
-	{
-		public byte[] Data { get; }
-		public int Length { get; }
-
-		public BlrData(byte[] data, int length)
-		{
-			Data = data;
-			Length = length;
-		}
-	}
-	public BlrData ToBlr()
+	public ReadOnlyMemory<byte> ToBlrMemory()
 	{
 		using (var blr = new MemoryStream(256))
 		{
@@ -292,9 +281,10 @@ internal sealed class Descriptor
 			blr.WriteByte(IscCodes.blr_end);
 			blr.WriteByte(IscCodes.blr_eoc);
 
-			return new BlrData(blr.ToArray(), length);
+			return new ReadOnlyMemory<byte>(blr.GetBuffer(), 0, length);
 		}
 	}
 
+	public ReadOnlySpan<byte> ToBlr() => ToBlrMemory().Span;
 	#endregion
 }

--- a/src/FirebirdSql.Data.FirebirdClient/Common/TypeDecoder.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/TypeDecoder.cs
@@ -93,6 +93,11 @@ internal static class TypeDecoder
 		return (year, month, day);
 	}
 
+	public static bool DecodeBoolean(ReadOnlySpan<byte> value)
+	{
+		return value[0] != 0;
+	}
+
 	public static bool DecodeBoolean(byte[] value)
 	{
 		return value[0] != 0;
@@ -103,9 +108,22 @@ internal static class TypeDecoder
 		var a = IPAddress.HostToNetworkOrder(BitConverter.ToInt32(value, 0));
 		var b = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value, 4));
 		var c = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value, 6));
-		var d = new[] { value[8], value[9], value[10], value[11], value[12], value[13], value[14], value[15] };
-		return new Guid(a, b, c, d);
+		return new Guid(a, b, c, value[8], value[9], value[10], value[11], value[12], value[13], value[14], value[15]);
 	}
+	public static Guid DecodeGuid(ReadOnlySpan<byte> value) =>
+		new Guid(
+			a: IPAddress.HostToNetworkOrder(BitConverter.ToInt32(value)),
+			b: IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value.Slice(4, 2))),
+			c: IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value.Slice(6, 2))),
+			d: value[8],
+			e: value[9],
+			f: value[10],
+			g: value[11],
+			h: value[12],
+			i: value[13],
+			j: value[14],
+			k: value[15]
+		);
 
 	public static int DecodeInt32(byte[] value)
 	{

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
 		<AssemblyName>FirebirdSql.Data.FirebirdClient</AssemblyName>
 		<RootNamespace>FirebirdSql.Data</RootNamespace>
 		<SignAssembly>true</SignAssembly>
@@ -58,7 +58,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="System.Memory" Version="4.5.5" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Compile Update="FirebirdClient\FbBatchCommand.cs" />

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -58,6 +58,7 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
+	  <PackageReference Include="System.Memory" Version="4.5.5" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Compile Update="FirebirdClient\FbBatchCommand.cs" />

--- a/src/Perf/Perf.csproj
+++ b/src/Perf/Perf.csproj
@@ -5,7 +5,7 @@
 		<SkipSourceLink>true</SkipSourceLink>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Perf/PerformanceBenchmark.cs
+++ b/src/Perf/PerformanceBenchmark.cs
@@ -1,0 +1,111 @@
+﻿using System.Diagnostics.Tracing;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using FirebirdSql.Data.FirebirdClient;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing.Parsers;
+
+namespace Perf;
+
+[Config(typeof(Config))]
+public class PerformanceBenchmark
+{
+	class Config : ManualConfig
+	{
+		private const ClrTraceEventParser.Keywords EventParserKeywords =
+			ClrTraceEventParser.Keywords.Exception
+			| ClrTraceEventParser.Keywords.GC
+			| ClrTraceEventParser.Keywords.Jit
+			| ClrTraceEventParser.Keywords.JitTracing // for the inlining events
+			| ClrTraceEventParser.Keywords.Loader
+			| ClrTraceEventParser.Keywords.NGen;
+
+		public Config()
+		{
+			AddJob(Job.ShortRun.WithRuntime(CoreRuntime.Core70));
+
+			AddDiagnoser(MemoryDiagnoser.Default);
+
+			AddDiagnoser(new EventPipeProfiler(providers: new[] {
+				new EventPipeProvider(
+					ClrTraceEventParser.ProviderName,
+					EventLevel.Verbose,
+					(long)EventParserKeywords
+				)
+			}));
+		}
+	}
+
+	protected readonly string ConnectionString = (new FbConnectionStringBuilder()
+	{
+		Database = Path.Join(Path.GetTempPath(), "FirebirdSql.Data.FirebirdClient.Benchmark.fb50.fdb"),
+		UserID = "SYSDBA",
+		Password = "masterkey",
+		ServerType = FbServerType.Embedded,
+		ClientLibrary = Path.Join(Path.GetTempPath(), @"firebird-binaries\fb50\fbclient.dll"),
+	}).ConnectionString;
+
+	[Params(10_000)]
+	public int Count { get; set; }
+
+	[Params(
+		"BIGINT",
+		"CHAR(255) CHARACTER SET UTF8",
+		"CHAR(255) CHARACTER SET OCTETS",
+		"BLOB SUB_TYPE TEXT CHARACTER SET UTF8",
+		"BLOB SUB_TYPE BINARY"
+	)]
+	public string DataType { get; set; }
+
+	[GlobalSetup(Target = nameof(Fetch))]
+	public void FetchGlobalSetup()
+	{
+		FbConnection.CreateDatabase(ConnectionString, 8192, false, true);
+	}
+
+	[GlobalCleanup]
+	public void GlobalCleanup()
+	{
+		FbConnection.ClearAllPools();
+		FbConnection.DropDatabase(ConnectionString);
+	}
+
+	[Benchmark]
+	public void Fetch()
+	{
+		using var conn = new FbConnection(ConnectionString);
+		conn.Open();
+
+		using var cmd = conn.CreateCommand();
+		cmd.CommandText = $@"
+			EXECUTE BLOCK RETURNS (result {DataType}) AS
+			DECLARE cnt INTEGER;
+			BEGIN
+				SELECT {GetFillExpression(DataType)} FROM rdb$database INTO result;
+				cnt = {Count};
+				WHILE (cnt > 0) DO
+				BEGIN
+					SUSPEND;
+					cnt = cnt - 1;
+				END
+			END
+		";
+
+		using var reader = cmd.ExecuteReader();
+		while (reader.Read())
+		{
+			_ = reader[0];
+		}
+	}
+	private static string GetFillExpression(string dataType) =>
+		dataType switch
+		{
+			{ } when dataType.StartsWith("BLOB") => $"LPAD('', 1023, '{dataType};')",
+			{ } when dataType.StartsWith("CHAR") => $"LPAD('', 255, '{dataType};')",
+			_ => "9223372036854775807" /* BIGINT */
+		};
+}

--- a/src/Perf/Program.cs
+++ b/src/Perf/Program.cs
@@ -15,7 +15,6 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
-using System.Reflection;
 using BenchmarkDotNet.Running;
 
 namespace Perf;
@@ -24,6 +23,8 @@ class Program
 {
 	static void Main(string[] args)
 	{
-		BenchmarkRunner.Run(Assembly.GetExecutingAssembly());
+		BenchmarkSwitcher
+			.FromAssembly(typeof(Program).Assembly)
+			.Run(args);
 	}
 }


### PR DESCRIPTION
Initial work to reduce memory allocations. 

Asking for guidance/opinions. Do not merge. 


### Before be56c23c7a623d7dfbe0132a2b6d479466d0ffc4
```
| Method | Count |             DataType |      Mean |     Error |   StdDev |       Gen0 |       Gen1 | Allocated |
|------- |------ |--------------------- |----------:|----------:|---------:|-----------:|-----------:|----------:|
|  Fetch | 10000 |               BIGINT |  56.14 ms |  0.714 ms | 0.039 ms |  1333.3333 |  1222.2222 |  10.86 MB |
|  Fetch | 10000 | BLOB SUB_TYPE BINARY | 182.51 ms | 56.430 ms | 3.093 ms | 24333.3333 | 12000.0000 | 196.11 MB |
|  Fetch | 10000 | BLOB (...) UTF8 [37] | 191.21 ms | 90.292 ms | 4.949 ms | 27000.0000 |  9000.0000 | 216.18 MB |
|  Fetch | 10000 | CHAR((...)CTETS [30] |  58.46 ms |  3.942 ms | 0.216 ms |  1625.0000 |   750.0000 |  13.31 MB |
|  Fetch | 10000 | CHAR((...) UTF8 [28] |  80.73 ms |  4.432 ms | 0.243 ms |  5666.6667 |  1333.3333 |  45.43 MB |
```


### After 6a641d7079db56c489c73dd3e5158b4319cee242
```
| Method | Count |             DataType |      Mean |     Error |   StdDev |       Gen0 |       Gen1 | Allocated |
|------- |------ |--------------------- |----------:|----------:|---------:|-----------:|-----------:|----------:|
|  Fetch | 10000 |               BIGINT |  22.34 ms |  4.823 ms | 0.264 ms |   593.7500 |   562.5000 |   4.91 MB |
|  Fetch | 10000 | BLOB SUB_TYPE BINARY | 139.91 ms | 59.043 ms | 3.236 ms | 23750.0000 | 11750.0000 | 190.15 MB |
|  Fetch | 10000 | BLOB (...) UTF8 [37] | 141.46 ms | 57.728 ms | 3.164 ms | 26250.0000 | 12750.0000 | 210.22 MB |
|  Fetch | 10000 | CHAR((...)CTETS [30] |  24.28 ms |  5.843 ms | 0.320 ms |   937.5000 |   906.2500 |   7.66 MB |
|  Fetch | 10000 | CHAR((...) UTF8 [28] |  44.76 ms |  8.676 ms | 0.476 ms |  3666.6667 |  1166.6667 |  29.78 MB |
```

For now, integers (`BIGINT` row in the above benchmarks) shows the most significant improvement. 

But there is also a lot of work yet to be done. Both in low level (Interop) as in strings management.


### How to run

To run the above benchmarks, run (in Powershell/Windows):

```powershell
.\download-firebird-binaries.ps1
.\benchmark.ps1 -Benchmark PerformanceBenchmark
```

The benchmark will use Firebird 5.0 Embedded. It should not conflict with any Firebird installed. 