### PR TITLE
Add RecordVersionStatistics flag on FbStatisticalFlags

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient.Tests/FbServicesTests.cs
+++ b/src/FirebirdSql.Data.FirebirdClient.Tests/FbServicesTests.cs
@@ -224,6 +224,22 @@ end";
 	}
 
 	[Test]
+	public async Task StatisticsRecordVersionTest()
+	{
+		var sb = new StringBuilder();
+		var statisticalSvc = new FbStatistical();
+		statisticalSvc.ConnectionString = BuildServicesConnectionString(ServerType, Compression, WireCrypt, true);
+		statisticalSvc.Options = FbStatisticalFlags.RecordVersionStatistics;
+		statisticalSvc.ServiceOutput += (object sender, ServiceOutputEventArgs e) =>
+		{
+			sb.AppendLine(e.Message);
+		};
+		await statisticalSvc.ExecuteAsync();
+		var statisticalOutput = sb.ToString();
+		Assert.IsTrue(statisticalOutput.Contains("Average record length"),"Record statistics not found");
+	}
+
+	[Test]
 	public async Task FbLogTest()
 	{
 		var logSvc = new FbLog();

--- a/src/FirebirdSql.Data.FirebirdClient/Services/FbStatisticalFlags.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Services/FbStatisticalFlags.cs
@@ -16,15 +16,43 @@
 //$Authors = Carlos Guzman Alvarez, Jiri Cincura (jiri@cincura.net)
 
 using System;
+using System.ComponentModel;
 
 namespace FirebirdSql.Data.Services;
 
+/// <summary>
+/// Flags used by FbStatistical.Options
+/// </summary>
 [Flags]
 public enum FbStatisticalFlags
 {
+	/// <summary>
+	/// analyze data pages
+	/// </summary>
 	DataPages = 0x01,
+
+	/// <summary>
+	/// DatabaseLog - no longer used by firebird
+	/// </summary>
 	DatabaseLog = 0x02,
+
+	/// <summary>
+	/// analyze header page ONLY
+	/// </summary>
 	HeaderPages = 0x04,
+
+	/// <summary>
+	/// analyze index leaf pages
+	/// </summary>
 	IndexPages = 0x08,
+
+	/// <summary>
+	/// analyze system relations in addition to user tables
+	/// </summary>
 	SystemTablesRelations = 0x10,
+
+	/// <summary>
+	/// analyze average record and version length
+	/// </summary>
+	RecordVersionStatistics = 0x20,
 }

--- a/src/FirebirdSql.Data.TestsBase/FbTestsBase.cs
+++ b/src/FirebirdSql.Data.TestsBase/FbTestsBase.cs
@@ -196,6 +196,7 @@ end";
 			builder.Database = FbTestsSetup.Database(serverType, compression, wireCrypt);
 		}
 		builder.ServerType = serverType;
+		builder.Port = FbTestsSetup.Port;
 		return builder;
 	}
 


### PR DESCRIPTION
Add missing option for analyze average record and version length.
Also xml document comments on the enum.