### PR TITLE
Support DESC-flag in migrations and scaffolding

### DIFF
--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Migrations/FbMigrationsSqlGenerator.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Migrations/FbMigrationsSqlGenerator.cs
@@ -201,6 +201,19 @@ public class FbMigrationsSqlGenerator : MigrationsSqlGenerator
 		{
 			builder.Append("UNIQUE ");
 		}
+
+		if (operation.IsDescending is not null && operation.IsDescending.Length > 0)
+		{
+			var isDescending = operation.IsDescending[0];
+			if (operation.IsDescending.Any(x => x != isDescending))
+				throw new NotSupportedException("Mixed order indices are not supported by Firebird.");
+
+			if (isDescending)
+			{
+				builder.Append("DESC ");
+			}
+		}
+
 		IndexTraits(operation, model, builder);
 		builder.Append("INDEX ");
 		builder.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name));


### PR DESCRIPTION
Add support for descending indices for EF-Core 7

As indices in Firebird are unidirectional, this PR looks only at the first flag in the list to determine whether the whole index is supposed to be descending. If this is not the behaviour that is being looked for, i am happy to modify my PR accordingly.