### PR TITLE
Update benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 obj
 out/
 .idea
+/BenchmarkDotNet.Artifacts

--- a/run-benchmark.ps1
+++ b/run-benchmark.ps1
@@ -1,0 +1,13 @@
+param(
+	[Parameter(Mandatory=$True)]
+	[ValidateSet('CommandBenchmark','PerformanceBenchmark')]
+	$Benchmark = 'CommandBenchmark'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Make a release build
+dotnet build .\src\Perf\Perf.csproj --configuration 'Release'
+
+# Run selected benchmark
+& .\src\Perf\bin\Release\net8.0\Perf.exe --filter "*$($Benchmark)*"

--- a/src/Perf/CommandBenchmark.cs
+++ b/src/Perf/CommandBenchmark.cs
@@ -34,7 +34,7 @@ public partial class CommandBenchmark
 		{
 			var baseJob = Job.Default
 				.WithWarmupCount(3)
-				.WithToolchain(CsProjCoreToolchain.NetCoreApp60)
+				.WithToolchain(CsProjCoreToolchain.NetCoreApp80)
 				.WithPlatform(Platform.X64)
 				.WithJit(Jit.RyuJit);
 			AddDiagnoser(MemoryDiagnoser.Default);

--- a/src/Perf/Perf.csproj
+++ b/src/Perf/Perf.csproj
@@ -5,7 +5,7 @@
 		<SkipSourceLink>true</SkipSourceLink>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -19,6 +19,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(Configuration.EndsWith('NuGet'))">
-		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="8.5.4" />
+		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.3.1" />
 	</ItemGroup>
 </Project>

--- a/src/Perf/PerformanceBenchmark.cs
+++ b/src/Perf/PerformanceBenchmark.cs
@@ -1,0 +1,109 @@
+﻿using System.Diagnostics.Tracing;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.CsProj;
+using FirebirdSql.Data.FirebirdClient;
+using Microsoft.Diagnostics.Tracing.Parsers;
+
+namespace Perf;
+
+[Config(typeof(Config))]
+public class PerformanceBenchmark
+{
+	class Config : ManualConfig
+	{
+		private const ClrTraceEventParser.Keywords EventParserKeywords =
+			ClrTraceEventParser.Keywords.Exception
+			| ClrTraceEventParser.Keywords.GC
+			| ClrTraceEventParser.Keywords.Jit
+			| ClrTraceEventParser.Keywords.JitTracing // for the inlining events
+			| ClrTraceEventParser.Keywords.Loader
+			| ClrTraceEventParser.Keywords.NGen;
+
+		public Config()
+		{
+			var baseJob = Job.ShortRun
+				.WithWarmupCount(3)
+				.WithToolchain(CsProjCoreToolchain.NetCoreApp80)
+				.WithPlatform(Platform.X64)
+				.WithJit(Jit.RyuJit);
+			AddDiagnoser(MemoryDiagnoser.Default);
+
+			AddDiagnoser(new EventPipeProfiler(providers: [
+				new(
+					ClrTraceEventParser.ProviderName,
+					EventLevel.Verbose,
+					(long)EventParserKeywords
+				)
+			]));
+
+			AddJob(baseJob.WithCustomBuildConfiguration("Release").WithId("Project"));
+			AddJob(baseJob.WithCustomBuildConfiguration("ReleaseNuGet").WithId("NuGet").AsBaseline());
+		}
+	}
+
+	protected const string ConnectionString = "database=localhost:benchmark.fdb;user=sysdba;password=masterkey";
+
+	[Params(10_000)]
+	public int Count { get; set; }
+
+	[Params(
+		"BIGINT",
+		"CHAR(255) CHARACTER SET UTF8",
+		"CHAR(255) CHARACTER SET OCTETS",
+		"BLOB SUB_TYPE TEXT CHARACTER SET UTF8",
+		"BLOB SUB_TYPE BINARY"
+	)]
+	public string DataType { get; set; }
+
+	[GlobalSetup(Target = nameof(Fetch))]
+	public void FetchGlobalSetup()
+	{
+		FbConnection.CreateDatabase(ConnectionString, 8192, false, true);
+	}
+
+	[GlobalCleanup]
+	public void GlobalCleanup()
+	{
+		FbConnection.ClearAllPools();
+		FbConnection.DropDatabase(ConnectionString);
+	}
+
+	[Benchmark]
+	public void Fetch()
+	{
+		using var conn = new FbConnection(ConnectionString);
+		conn.Open();
+
+		using var cmd = conn.CreateCommand();
+		cmd.CommandText = $@"
+			EXECUTE BLOCK RETURNS (result {DataType}) AS
+			DECLARE cnt INTEGER;
+			BEGIN
+				SELECT {GetFillExpression(DataType)} FROM rdb$database INTO result;
+				cnt = {Count};
+				WHILE (cnt > 0) DO
+				BEGIN
+					SUSPEND;
+					cnt = cnt - 1;
+				END
+			END
+		";
+
+		using var reader = cmd.ExecuteReader();
+		while (reader.Read())
+		{
+			_ = reader[0];
+		}
+	}
+	private static string GetFillExpression(string dataType) =>
+		dataType switch
+		{
+			{ } when dataType.StartsWith("BLOB") => $"LPAD('', 1023, '{dataType};')",
+			{ } when dataType.StartsWith("CHAR") => $"LPAD('', 255, '{dataType};')",
+			_ => "9223372036854775807" /* BIGINT */
+		};
+}

--- a/src/Perf/Program.cs
+++ b/src/Perf/Program.cs
@@ -15,7 +15,6 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
-using System.Reflection;
 using BenchmarkDotNet.Running;
 
 namespace Perf;
@@ -24,6 +23,8 @@ class Program
 {
 	static void Main(string[] args)
 	{
-		BenchmarkRunner.Run(Assembly.GetExecutingAssembly());
+		BenchmarkSwitcher
+			.FromAssembly(typeof(Program).Assembly)
+			.Run(args);
 	}
 }


### PR DESCRIPTION
First part of #122.

- Updates BenchmarkDotnet to latest version and to use .NET8.
- Updates FirebirdClient nuget baseline package to latest.
- Adds PerformanceBenchmark (useful for next PRs).
- Adds `run-benchmark.ps1` helper script.
