### PR TITLE
Performance: Uses `ReadOnlySpan`

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,6 @@ $baseDir = Split-Path -Parent $PSCommandPath
 $outDir = "$baseDir\out"
 $versionProvider = ''
 $versionEFCore = ''
-$versionEF6 = ''
 
 function Clean() {
 	if (Test-Path $outDir) {
@@ -39,17 +38,14 @@ function Versions() {
 	}
 	$script:versionProvider = v $baseDir\src\FirebirdSql.Data.FirebirdClient\bin\$Configuration\net8.0\FirebirdSql.Data.FirebirdClient.dll
 	$script:versionEFCore = v $baseDir\src\FirebirdSql.EntityFrameworkCore.Firebird\bin\$Configuration\net8.0\FirebirdSql.EntityFrameworkCore.Firebird.dll
-	$script:versionEF6 = v $baseDir\src\EntityFramework.Firebird\bin\$Configuration\net48\EntityFramework.Firebird.dll
 }
 
 function NuGets() {
 	cp $baseDir\src\FirebirdSql.Data.FirebirdClient\bin\$Configuration\FirebirdSql.Data.FirebirdClient.$versionProvider.nupkg $outDir
 	cp $baseDir\src\FirebirdSql.EntityFrameworkCore.Firebird\bin\$Configuration\FirebirdSql.EntityFrameworkCore.Firebird.$versionEFCore.nupkg $outDir
-	cp $baseDir\src\EntityFramework.Firebird\bin\$Configuration\EntityFramework.Firebird.$versionEF6.nupkg $outDir
 
 	cp $baseDir\src\FirebirdSql.Data.FirebirdClient\bin\$Configuration\FirebirdSql.Data.FirebirdClient.$versionProvider.snupkg $outDir
 	cp $baseDir\src\FirebirdSql.EntityFrameworkCore.Firebird\bin\$Configuration\FirebirdSql.EntityFrameworkCore.Firebird.$versionEFCore.snupkg $outDir
-	cp $baseDir\src\EntityFramework.Firebird\bin\$Configuration\EntityFramework.Firebird.$versionEF6.snupkg $outDir
 }
 
 Clean

--- a/src/EntityFramework.Firebird/EntityFramework.Firebird.csproj
+++ b/src/EntityFramework.Firebird/EntityFramework.Firebird.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1</TargetFrameworks>
 		<AssemblyName>EntityFramework.Firebird</AssemblyName>
 		<RootNamespace>EntityFramework.Firebird</RootNamespace>
 		<SignAssembly>true</SignAssembly>
@@ -47,10 +47,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="EntityFramework" Version="$(EF6ReferencePackageVersion)" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)'=='net48'">
-		<Reference Include="System.Configuration" />
-		<Reference Include="Microsoft.CSharp" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
 	</ItemGroup>

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/DataProviderStreamWrapper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/DataProviderStreamWrapper.cs
@@ -15,6 +15,7 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -43,10 +44,23 @@ sealed class DataProviderStreamWrapper : IDataProvider
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Write(ReadOnlySpan<byte> buffer)
+	{
+		_stream.Write(buffer);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Write(byte[] buffer, int offset, int count)
 	{
 		_stream.Write(buffer, offset, count);
 	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+	{
+		await _stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+	}
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ValueTask WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
 	{

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
@@ -33,7 +33,7 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 
 	readonly IDataProvider _dataProvider;
 
-	readonly Queue<byte> _outputBuffer;
+	readonly MemoryStream _outputBuffer;
 	readonly Queue<byte> _inputBuffer;
 	readonly byte[] _readBuffer;
 
@@ -48,7 +48,7 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 	{
 		_dataProvider = dataProvider;
 
-		_outputBuffer = new Queue<byte>(PreferredBufferSize);
+		_outputBuffer = new MemoryStream(PreferredBufferSize);
 		_inputBuffer = new Queue<byte>(PreferredBufferSize);
 		_readBuffer = new byte[PreferredBufferSize];
 	}
@@ -120,22 +120,31 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		return dataLength;
 	}
 
+	public void Write(ReadOnlySpan<byte> buffer)
+	{
+		_outputBuffer.Write(buffer);
+	}
+
 	public void Write(byte[] buffer, int offset, int count)
 	{
-		for (var i = offset; i < count; i++)
-			_outputBuffer.Enqueue(buffer[offset + i]);
+		_outputBuffer.Write(buffer, offset, count);
 	}
+
+	public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+	{
+		await _outputBuffer.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+	}
+
 	public ValueTask WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
 	{
-		for (var i = offset; i < count; i++)
-			_outputBuffer.Enqueue(buffer[offset + i]);
+		_outputBuffer.Write(buffer, offset, count);
 		return ValueTask2.CompletedTask;
 	}
 
 	public void Flush()
 	{
 		var buffer = _outputBuffer.ToArray();
-		_outputBuffer.Clear();
+		_outputBuffer.SetLength(0);
 		var count = buffer.Length;
 		if (_compressor != null)
 		{
@@ -160,7 +169,7 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 	public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
 	{
 		var buffer = _outputBuffer.ToArray();
-		_outputBuffer.Clear();
+		_outputBuffer.SetLength(0);
 		var count = buffer.Length;
 		if (_compressor != null)
 		{

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IDataProvider.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IDataProvider.cs
@@ -15,6 +15,7 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,7 +26,10 @@ interface IDataProvider
 	int Read(byte[] buffer, int offset, int count);
 	ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default);
 
+	void Write(ReadOnlySpan<byte> buffer);
 	void Write(byte[] buffer, int offset, int count);
+
+	ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default);
 	ValueTask WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default);
 
 	void Flush();

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version16/GdsBatch.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version16/GdsBatch.cs
@@ -43,9 +43,9 @@ internal class GdsBatch : BatchBase
 
 		Database.Xdr.Write(IscCodes.op_batch_create);
 		Database.Xdr.Write(_statement.Handle); // p_batch_statement
-		var blr = _statement.Parameters.ToBlr();
-		Database.Xdr.WriteBuffer(blr.Data); // p_batch_blr
-		Database.Xdr.Write(blr.Length); // p_batch_msglen
+		var blr = _statement.Parameters.ToBlrSpan(out var blrMsgLen);
+		Database.Xdr.WriteBuffer(blr); // p_batch_blr
+		Database.Xdr.Write(blrMsgLen); // p_batch_msglen
 		var pb = _statement.CreateBatchParameterBuffer();
 		if (_statement.ReturnRecordsAffected)
 		{
@@ -96,9 +96,9 @@ internal class GdsBatch : BatchBase
 
 		await Database.Xdr.WriteAsync(IscCodes.op_batch_create, cancellationToken).ConfigureAwait(false);
 		await Database.Xdr.WriteAsync(_statement.Handle, cancellationToken).ConfigureAwait(false); // p_batch_statement
-		var blr = _statement.Parameters.ToBlr();
-		await Database.Xdr.WriteBufferAsync(blr.Data, cancellationToken).ConfigureAwait(false); // p_batch_blr
-		await Database.Xdr.WriteAsync(blr.Length, cancellationToken).ConfigureAwait(false); // p_batch_msglen
+		var blr = _statement.Parameters.ToBlrMemory(out var blrMsgLen);
+		await Database.Xdr.WriteBufferAsync(blr, cancellationToken).ConfigureAwait(false); // p_batch_blr
+		await Database.Xdr.WriteAsync(blrMsgLen, cancellationToken).ConfigureAwait(false); // p_batch_msglen
 		var pb = _statement.CreateBatchParameterBuffer();
 		if (_statement.ReturnRecordsAffected)
 		{

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLDA.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLDA.cs
@@ -15,16 +15,12 @@
 
 //$Authors = Carlos Guzman Alvarez, Jiri Cincura (jiri@cincura.net)
 
-using System.Runtime.InteropServices;
-
 namespace FirebirdSql.Data.Client.Native.Marshalers;
 
-[StructLayout(LayoutKind.Sequential)]
-internal struct XSQLDA
+internal unsafe struct XSQLDA_STRUCT
 {
 	public short version;
-	[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 8)]
-	public string sqldaid;
+	public fixed byte sqldaid[8];
 	public int sqldabc;
 	public short sqln;
 	public short sqld;

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLVAR.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XSQLVAR.cs
@@ -16,12 +16,10 @@
 //$Authors = Carlos Guzman Alvarez, Jiri Cincura (jiri@cincura.net)
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace FirebirdSql.Data.Client.Native.Marshalers;
 
-[StructLayout(LayoutKind.Sequential)]
-internal class XSQLVAR
+internal unsafe struct XSQLVAR_STRUCT
 {
 	public short sqltype;
 	public short sqlscale;
@@ -30,15 +28,11 @@ internal class XSQLVAR
 	public IntPtr sqldata;
 	public IntPtr sqlind;
 	public short sqlname_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] sqlname;
+	public fixed byte sqlname[32];
 	public short relname_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] relname;
+	public fixed byte relname[32];
 	public short ownername_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] ownername;
+	public fixed byte ownername[32];
 	public short aliasname_length;
-	[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-	public byte[] aliasname;
+	public fixed byte aliasname[32];
 }

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XsqldaMarshaler.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/Marshalers/XsqldaMarshaler.cs
@@ -17,31 +17,24 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.IO;
 using FirebirdSql.Data.Common;
-using System.Threading.Tasks;
 
 namespace FirebirdSql.Data.Client.Native.Marshalers;
 
 internal static class XsqldaMarshaler
 {
-	private static int SizeOfXSQLDA = Marshal.SizeOf<XSQLDA>();
-	private static int SizeOfXSQLVAR = Marshal.SizeOf<XSQLVAR>();
-
-	public static void CleanUpNativeData(ref IntPtr pNativeData)
+	public unsafe static void CleanUpNativeData(ref IntPtr pNativeData)
 	{
 		if (pNativeData != IntPtr.Zero)
 		{
-			var xsqlda = Marshal.PtrToStructure<XSQLDA>(pNativeData);
+			var xsqlda = *(XSQLDA_STRUCT*)pNativeData;
 
-			Marshal.DestroyStructure<XSQLDA>(pNativeData);
+			Marshal.DestroyStructure<XSQLDA_STRUCT>(pNativeData);
 
 			for (var i = 0; i < xsqlda.sqln; i++)
 			{
 				var ptr = IntPtr.Add(pNativeData, ComputeLength(i));
-
-				var sqlvar = new XSQLVAR();
-				MarshalXSQLVARNativeToManaged(ptr, sqlvar, true);
+				var sqlvar = *(XSQLVAR_STRUCT*)ptr;
 
 				if (sqlvar.sqldata != IntPtr.Zero)
 				{
@@ -55,7 +48,7 @@ internal static class XsqldaMarshaler
 					sqlvar.sqlind = IntPtr.Zero;
 				}
 
-				Marshal.DestroyStructure<XSQLVAR>(ptr);
+				Marshal.DestroyStructure<XSQLVAR_STRUCT>(ptr);
 			}
 
 			Marshal.FreeHGlobal(pNativeData);
@@ -64,90 +57,75 @@ internal static class XsqldaMarshaler
 		}
 	}
 
-	public static IntPtr MarshalManagedToNative(Charset charset, Descriptor descriptor)
+	public unsafe static IntPtr MarshalManagedToNative(Charset charset, Descriptor descriptor)
 	{
-		var xsqlda = new XSQLDA
+		var xsqlda = new XSQLDA_STRUCT
 		{
 			version = descriptor.Version,
 			sqln = descriptor.Count,
 			sqld = descriptor.ActualCount
 		};
 
-		var xsqlvar = new XSQLVAR[descriptor.Count];
+		var size = ComputeLength(xsqlda.sqln);
+		var ptr = Marshal.AllocHGlobal(size);
+		Marshal.StructureToPtr(xsqlda, ptr, true);
 
-		for (var i = 0; i < xsqlvar.Length; i++)
+		var xsqlvar = new XSQLVAR_STRUCT();
+		for (var i = 0; i < xsqlda.sqln; i++)
 		{
-			xsqlvar[i] = new XSQLVAR
-			{
-				sqltype = descriptor[i].DataType,
-				sqlscale = descriptor[i].NumericScale,
-				sqlsubtype = descriptor[i].SubType,
-				sqllen = descriptor[i].Length
-			};
-
+			xsqlvar.sqltype = descriptor[i].DataType;
+			xsqlvar.sqlscale = descriptor[i].NumericScale;
+			xsqlvar.sqlsubtype = descriptor[i].SubType;
+			xsqlvar.sqllen = descriptor[i].Length;
 
 			if (descriptor[i].HasDataType() && descriptor[i].DbDataType != DbDataType.Null)
 			{
 				var buffer = descriptor[i].DbValue.GetBytes();
-				xsqlvar[i].sqldata = Marshal.AllocHGlobal(buffer.Length);
-				Marshal.Copy(buffer, 0, xsqlvar[i].sqldata, buffer.Length);
+				xsqlvar.sqldata = Marshal.AllocHGlobal(buffer.Length);
+				Marshal.Copy(buffer, 0, xsqlvar.sqldata, buffer.Length);
 			}
 			else
 			{
-				xsqlvar[i].sqldata = Marshal.AllocHGlobal(0);
+				xsqlvar.sqldata = Marshal.AllocHGlobal(0);
 			}
 
-			xsqlvar[i].sqlind = Marshal.AllocHGlobal(Marshal.SizeOf<short>());
-			Marshal.WriteInt16(xsqlvar[i].sqlind, descriptor[i].NullFlag);
+			xsqlvar.sqlind = Marshal.AllocHGlobal(Marshal.SizeOf<short>());
+			Marshal.WriteInt16(xsqlvar.sqlind, descriptor[i].NullFlag);
 
-			xsqlvar[i].sqlname = GetStringBuffer(charset, descriptor[i].Name);
-			xsqlvar[i].sqlname_length = (short)descriptor[i].Name.Length;
+			fixed (char* psqlname = descriptor[i].Name)
+			fixed (char* prelname = descriptor[i].Relation)
+			fixed (char* pownername = descriptor[i].Owner)
+			fixed (char* paliasname = descriptor[i].Alias)
+			{
+				xsqlvar.sqlname_length = (short)descriptor[i].Name.Length;
+				charset.Encoding.GetBytes(psqlname, descriptor[i].Name.Length, xsqlvar.sqlname, 32);
 
-			xsqlvar[i].relname = GetStringBuffer(charset, descriptor[i].Relation);
-			xsqlvar[i].relname_length = (short)descriptor[i].Relation.Length;
+				xsqlvar.relname_length = (short)descriptor[i].Relation.Length;
+				charset.Encoding.GetBytes(prelname, descriptor[i].Relation.Length, xsqlvar.relname, 32);
 
-			xsqlvar[i].ownername = GetStringBuffer(charset, descriptor[i].Owner);
-			xsqlvar[i].ownername_length = (short)descriptor[i].Owner.Length;
+				xsqlvar.ownername_length = (short)descriptor[i].Owner.Length;
+				charset.Encoding.GetBytes(pownername, descriptor[i].Owner.Length, xsqlvar.ownername, 32);
 
-			xsqlvar[i].aliasname = GetStringBuffer(charset, descriptor[i].Alias);
-			xsqlvar[i].aliasname_length = (short)descriptor[i].Alias.Length;
-		}
+				xsqlvar.aliasname_length = (short)descriptor[i].Alias.Length;
+				charset.Encoding.GetBytes(paliasname, descriptor[i].Alias.Length, xsqlvar.aliasname, 32);
 
-		return MarshalManagedToNative(xsqlda, xsqlvar);
-	}
-
-	public static IntPtr MarshalManagedToNative(XSQLDA xsqlda, XSQLVAR[] xsqlvar)
-	{
-		var size = ComputeLength(xsqlda.sqln);
-		var ptr = Marshal.AllocHGlobal(size);
-
-		Marshal.StructureToPtr(xsqlda, ptr, true);
-
-		for (var i = 0; i < xsqlvar.Length; i++)
-		{
-			var offset = ComputeLength(i);
-			Marshal.StructureToPtr(xsqlvar[i], IntPtr.Add(ptr, offset), true);
+				var offset = ComputeLength(i);
+				Marshal.StructureToPtr(xsqlvar, IntPtr.Add(ptr, offset), true);
+			}
 		}
 
 		return ptr;
 	}
 
-	public static Descriptor MarshalNativeToManaged(Charset charset, IntPtr pNativeData)
+	public unsafe static Descriptor MarshalNativeToManaged(Charset charset, IntPtr pNativeData, bool fetching = false)
 	{
-		return MarshalNativeToManaged(charset, pNativeData, false);
-	}
-
-	public static Descriptor MarshalNativeToManaged(Charset charset, IntPtr pNativeData, bool fetching)
-	{
-		var xsqlda = Marshal.PtrToStructure<XSQLDA>(pNativeData);
+		var xsqlda = *(XSQLDA_STRUCT*)pNativeData;
 
 		var descriptor = new Descriptor(xsqlda.sqln) { ActualCount = xsqlda.sqld };
 
-		var xsqlvar = new XSQLVAR();
 		for (var i = 0; i < xsqlda.sqln; i++)
 		{
-			var ptr = IntPtr.Add(pNativeData, ComputeLength(i));
-			MarshalXSQLVARNativeToManaged(ptr, xsqlvar);
+			var xsqlvar = *(XSQLVAR_STRUCT*)IntPtr.Add(pNativeData, ComputeLength(i));
 
 			descriptor[i].DataType = xsqlvar.sqltype;
 			descriptor[i].NumericScale = xsqlvar.sqlscale;
@@ -162,54 +140,23 @@ internal static class XsqldaMarshaler
 			{
 				if (descriptor[i].NullFlag != -1)
 				{
-					descriptor[i].SetValue(GetBytes(xsqlvar));
+					descriptor[i].SetValue(GetBytes(ref xsqlvar));
 				}
 			}
 
-			descriptor[i].Name = GetString(charset, xsqlvar.sqlname, xsqlvar.sqlname_length);
-			descriptor[i].Relation = GetString(charset, xsqlvar.relname, xsqlvar.relname_length);
-			descriptor[i].Owner = GetString(charset, xsqlvar.ownername, xsqlvar.ownername_length);
-			descriptor[i].Alias = GetString(charset, xsqlvar.aliasname, xsqlvar.aliasname_length);
+			descriptor[i].Name = charset.Encoding.GetString(xsqlvar.sqlname, xsqlvar.sqlname_length);
+			descriptor[i].Relation = charset.Encoding.GetString(xsqlvar.relname, xsqlvar.relname_length);
+			descriptor[i].Owner = charset.Encoding.GetString(xsqlvar.ownername, xsqlvar.ownername_length);
+			descriptor[i].Alias = charset.Encoding.GetString(xsqlvar.aliasname, xsqlvar.aliasname_length);
 		}
 
 		return descriptor;
 	}
 
-	private static void MarshalXSQLVARNativeToManaged(IntPtr ptr, XSQLVAR xsqlvar, bool onlyPointers = false)
-	{
-		unsafe
-		{
-			using (var reader = new BinaryReader(new UnmanagedMemoryStream((byte*)ptr.ToPointer(), SizeOfXSQLVAR)))
-			{
-				if (!onlyPointers) xsqlvar.sqltype = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				if (!onlyPointers) xsqlvar.sqlscale = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				if (!onlyPointers) xsqlvar.sqlsubtype = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				if (!onlyPointers) xsqlvar.sqllen = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				xsqlvar.sqldata = reader.ReadIntPtr();
-				xsqlvar.sqlind = reader.ReadIntPtr();
-				if (!onlyPointers) xsqlvar.sqlname_length = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				if (!onlyPointers) xsqlvar.sqlname = reader.ReadBytes(32); else reader.BaseStream.Position += 32;
-				if (!onlyPointers) xsqlvar.relname_length = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				if (!onlyPointers) xsqlvar.relname = reader.ReadBytes(32); else reader.BaseStream.Position += 32;
-				if (!onlyPointers) xsqlvar.ownername_length = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				if (!onlyPointers) xsqlvar.ownername = reader.ReadBytes(32); else reader.BaseStream.Position += 32;
-				if (!onlyPointers) xsqlvar.aliasname_length = reader.ReadInt16(); else reader.BaseStream.Position += sizeof(short);
-				if (!onlyPointers) xsqlvar.aliasname = reader.ReadBytes(32); else reader.BaseStream.Position += 32;
-			}
-		}
-	}
+	private unsafe static int ComputeLength(int n) =>
+		sizeof(XSQLDA_STRUCT) + (n * sizeof(XSQLVAR_STRUCT)) + (IntPtr.Size == 8 ? 4 : 0);
 
-	private static int ComputeLength(int n)
-	{
-		var length = (SizeOfXSQLDA + n * SizeOfXSQLVAR);
-		if (IntPtr.Size == 8)
-		{
-			length += 4;
-		}
-		return length;
-	}
-
-	private static byte[] GetBytes(XSQLVAR xsqlvar)
+	private static byte[] GetBytes(ref XSQLVAR_STRUCT xsqlvar)
 	{
 		if (xsqlvar.sqllen == 0 || xsqlvar.sqldata == IntPtr.Zero)
 		{
@@ -255,23 +202,5 @@ internal static class XsqldaMarshaler
 			default:
 				throw TypeHelper.InvalidDataType(type);
 		}
-	}
-
-	private static byte[] GetStringBuffer(Charset charset, string value)
-	{
-		var buffer = new byte[32];
-		charset.GetBytes(value, 0, value.Length, buffer, 0);
-		return buffer;
-	}
-
-	private static string GetString(Charset charset, byte[] buffer)
-	{
-		var value = charset.GetString(buffer);
-		return value.TrimEnd('\0', ' ');
-	}
-
-	private static string GetString(Charset charset, byte[] buffer, short bufferLength)
-	{
-		return charset.GetString(buffer, 0, bufferLength);
 	}
 }

--- a/src/FirebirdSql.Data.FirebirdClient/Common/Descriptor.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/Descriptor.cs
@@ -98,23 +98,13 @@ internal sealed class Descriptor
 		}
 	}
 
-	internal sealed class BlrData
-	{
-		public byte[] Data { get; }
-		public int Length { get; }
+	public ReadOnlyMemory<byte> ToBlrMemory() => ToBlrMemory(out int _);
 
-		public BlrData(byte[] data, int length)
-		{
-			Data = data;
-			Length = length;
-		}
-	}
-	public BlrData ToBlr()
+	public ReadOnlyMemory<byte> ToBlrMemory(out int length)
 	{
+		length = 0;
 		using (var blr = new MemoryStream(256))
 		{
-			var length = 0;
-
 			blr.WriteByte(IscCodes.blr_version5);
 			blr.WriteByte(IscCodes.blr_begin);
 			blr.WriteByte(IscCodes.blr_message);
@@ -292,9 +282,14 @@ internal sealed class Descriptor
 			blr.WriteByte(IscCodes.blr_end);
 			blr.WriteByte(IscCodes.blr_eoc);
 
-			return new BlrData(blr.ToArray(), length);
+			var buf = blr.GetBuffer();
+			return new ReadOnlyMemory<byte>(buf, 0, buf.Length);
 		}
 	}
+
+	public ReadOnlySpan<byte> ToBlrSpan() => ToBlrMemory(out int _).Span;
+
+	public ReadOnlySpan<byte> ToBlrSpan(out int length) => ToBlrMemory(out length).Span;
 
 	#endregion
 }

--- a/src/FirebirdSql.Data.FirebirdClient/Common/TypeDecoder.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/TypeDecoder.cs
@@ -93,6 +93,11 @@ internal static class TypeDecoder
 		return (year, month, day);
 	}
 
+	public static bool DecodeBoolean(ReadOnlySpan<byte> value)
+	{
+		return value[0] != 0;
+	}
+
 	public static bool DecodeBoolean(byte[] value)
 	{
 		return value[0] != 0;
@@ -103,9 +108,22 @@ internal static class TypeDecoder
 		var a = IPAddress.HostToNetworkOrder(BitConverter.ToInt32(value, 0));
 		var b = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value, 4));
 		var c = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value, 6));
-		var d = new[] { value[8], value[9], value[10], value[11], value[12], value[13], value[14], value[15] };
-		return new Guid(a, b, c, d);
+		return new Guid(a, b, c, value[8], value[9], value[10], value[11], value[12], value[13], value[14], value[15]);
 	}
+	public static Guid DecodeGuid(ReadOnlySpan<byte> value) =>
+		new Guid(
+			a: IPAddress.HostToNetworkOrder(BitConverter.ToInt32(value)),
+			b: IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value.Slice(4, 2))),
+			c: IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value.Slice(6, 2))),
+			d: value[8],
+			e: value[9],
+			f: value[10],
+			g: value[11],
+			h: value[12],
+			i: value[13],
+			j: value[14],
+			k: value[15]
+		);
 
 	public static int DecodeInt32(byte[] value)
 	{

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -61,6 +61,7 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
+	  <PackageReference Include="System.Memory" Version="4.5.5" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Compile Update="FirebirdClient\FbBatchCommand.cs" />

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdSql.Data.FirebirdClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
 		<AssemblyName>FirebirdSql.Data.FirebirdClient</AssemblyName>
 		<RootNamespace>FirebirdSql.Data</RootNamespace>
 		<SignAssembly>true</SignAssembly>
@@ -38,17 +38,7 @@
 		<None Include="..\..\license.txt" Pack="true" PackagePath="" />
 		<None Include="..\..\firebird-logo.png" Pack="true" PackagePath="" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)'=='net48'">
-		<Reference Include="System.Transactions" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
 	</ItemGroup>


### PR DESCRIPTION
Last piece of #122.

Based on #130 / https://github.com/cincuranet/FirebirdSql.Data.FirebirdClient/commit/5561ec41b8ad3274e6cdf2bf4c9a376e7e80299d (needs `XSQLDA` changes). 

⚠️ This one needs to drop support for `net48` and `netstandard2.0` since [there is no `ReadOnlySpan`](https://stackoverflow.com/a/73939829/33244) on them.
