### PR TITLE
Add support for Int64 in DbValue.GetTime() when the value represents ticks of a TimeOnly property.

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient/Common/DbValue.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/DbValue.cs
@@ -367,6 +367,7 @@ internal sealed class DbValue
 #if NET6_0_OR_GREATER
 			TimeOnly to => TypeEncoder.EncodeTime(to),
 #endif
+			Int64 ns => TypeEncoder.EncodeTime(TimeSpan.FromTicks(ns)),
 			_ => TypeEncoder.EncodeTime(TypeHelper.DateTimeTimeToTimeSpan(GetDateTime())),
 		};
 	}


### PR DESCRIPTION
Some Orm frameworks like ServiceStack.OrmLite convert TimeOnly property values to Ticks and pass an Int64 value when creating parameters or set the field value, instead of passing a TimeOnly object. 
With this change it will be possible to use this kind of framework without getting conversion errors.